### PR TITLE
Fix version update

### DIFF
--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -112,6 +112,7 @@ update_version(){
     mvn -e ${MAVEN_ARGS} -f ${WS_DIR}/pom.xml versions:set \
         -DgenerateBackupPoms=false \
         -DnewVersion="${FULL_VERSION}" \
+        -DupdateMatchingVersions=false \
         -DprocessAllModules=true
 }
 


### PR DESCRIPTION
`versions:set` had a bizarre behavior where it was setting some versions back to a SNAPSHOT version. Not sure why, but setting `updateMatchingVersions=false` seems to fix it.