### PR TITLE
3.x: Update helidon version to 3.2.7-SNAPSHOT

### DIFF
--- a/examples/config/basics/pom.xml
+++ b/examples/config/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/changes/pom.xml
+++ b/examples/config/changes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/git/pom.xml
+++ b/examples/config/git/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/mapping/pom.xml
+++ b/examples/config/mapping/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/metadata/pom.xml
+++ b/examples/config/metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/overrides/pom.xml
+++ b/examples/config/overrides/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/profiles/pom.xml
+++ b/examples/config/profiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/sources/pom.xml
+++ b/examples/config/sources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/cors/pom.xml
+++ b/examples/cors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/dbclient/jdbc/pom.xml
+++ b/examples/dbclient/jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/dbclient/mongodb/pom.xml
+++ b/examples/dbclient/mongodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/dbclient/pokemons/pom.xml
+++ b/examples/dbclient/pokemons/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.employee</groupId>

--- a/examples/graphql/basics/pom.xml
+++ b/examples/graphql/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.graphql</groupId>

--- a/examples/grpc/basics/pom.xml
+++ b/examples/grpc/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/client-standalone/pom.xml
+++ b/examples/grpc/client-standalone/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/common/pom.xml
+++ b/examples/grpc/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/metrics/pom.xml
+++ b/examples/grpc/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/microprofile/basic-client/pom.xml
+++ b/examples/grpc/microprofile/basic-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc.microprofile</groupId>

--- a/examples/grpc/microprofile/basic-server-implicit/pom.xml
+++ b/examples/grpc/microprofile/basic-server-implicit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc-microprofile.basic</groupId>

--- a/examples/grpc/microprofile/metrics/pom.xml
+++ b/examples/grpc/microprofile/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc-microprofile</groupId>

--- a/examples/grpc/opentracing/pom.xml
+++ b/examples/grpc/opentracing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security-abac/pom.xml
+++ b/examples/grpc/security-abac/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security-outbound/pom.xml
+++ b/examples/grpc/security-outbound/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security/pom.xml
+++ b/examples/grpc/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/health/basics/pom.xml
+++ b/examples/health/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.health</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/jedis/pom.xml
+++ b/examples/integrations/cdi/jedis/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/micrometer/mp/pom.xml
+++ b/examples/integrations/micrometer/mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/integrations/micrometer/se/pom.xml
+++ b/examples/integrations/micrometer/se/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/micronaut/data/pom.xml
+++ b/examples/integrations/micronaut/data/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations</groupId>

--- a/examples/integrations/microstream/greetings-mp/pom.xml
+++ b/examples/integrations/microstream/greetings-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/microstream/greetings-se/pom.xml
+++ b/examples/integrations/microstream/greetings-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/neo4j/neo4j-mp/pom.xml
+++ b/examples/integrations/neo4j/neo4j-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.neo4j</groupId>

--- a/examples/integrations/neo4j/neo4j-se/pom.xml
+++ b/examples/integrations/neo4j/neo4j-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.neo4j</groupId>

--- a/examples/integrations/oci/atp-cdi/pom.xml
+++ b/examples/integrations/oci/atp-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/atp-reactive/pom.xml
+++ b/examples/integrations/oci/atp-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/metrics-reactive/pom.xml
+++ b/examples/integrations/oci/metrics-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/objectstorage-cdi/pom.xml
+++ b/examples/integrations/oci/objectstorage-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/objectstorage-reactive/pom.xml
+++ b/examples/integrations/oci/objectstorage-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/vault-cdi/pom.xml
+++ b/examples/integrations/oci/vault-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/vault-reactive/pom.xml
+++ b/examples/integrations/oci/vault-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/vault/hcp-cdi/pom.xml
+++ b/examples/integrations/vault/hcp-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/vault/hcp-reactive/pom.xml
+++ b/examples/integrations/vault/hcp-reactive/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/jbatch/pom.xml
+++ b/examples/jbatch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.jbatch</groupId>

--- a/examples/logging/jul/pom.xml
+++ b/examples/logging/jul/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/log4j/pom.xml
+++ b/examples/logging/log4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/logback-aot/pom.xml
+++ b/examples/logging/logback-aot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/slf4j/pom.xml
+++ b/examples/logging/slf4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/media/multipart/pom.xml
+++ b/examples/media/multipart/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.media</groupId>

--- a/examples/messaging/jms-websocket-mp/pom.xml
+++ b/examples/messaging/jms-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.jms</groupId>

--- a/examples/messaging/jms-websocket-se/pom.xml
+++ b/examples/messaging/jms-websocket-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.jms</groupId>

--- a/examples/messaging/kafka-websocket-mp/pom.xml
+++ b/examples/messaging/kafka-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.mp</groupId>

--- a/examples/messaging/kafka-websocket-se/pom.xml
+++ b/examples/messaging/kafka-websocket-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.se</groupId>

--- a/examples/messaging/oracle-aq-websocket-mp/pom.xml
+++ b/examples/messaging/oracle-aq-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.aq</groupId>

--- a/examples/messaging/weblogic-jms-mp/pom.xml
+++ b/examples/messaging/weblogic-jms-mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.wls</groupId>

--- a/examples/metrics/exemplar/pom.xml
+++ b/examples/metrics/exemplar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/filtering/mp/pom.xml
+++ b/examples/metrics/filtering/mp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/filtering/se/pom.xml
+++ b/examples/metrics/filtering/se/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/http-status-count-se/pom.xml
+++ b/examples/metrics/http-status-count-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/metrics/kpi/pom.xml
+++ b/examples/metrics/kpi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/microprofile/bean-validation/pom.xml
+++ b/examples/microprofile/bean-validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/cors/pom.xml
+++ b/examples/microprofile/cors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/graphql/pom.xml
+++ b/examples/microprofile/graphql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/http-status-count-mp/pom.xml
+++ b/examples/microprofile/http-status-count-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/microprofile/idcs/pom.xml
+++ b/examples/microprofile/idcs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/lra/pom.xml
+++ b/examples/microprofile/lra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/messaging-sse/pom.xml
+++ b/examples/microprofile/messaging-sse/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/multipart/pom.xml
+++ b/examples/microprofile/multipart/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/multiport/pom.xml
+++ b/examples/microprofile/multiport/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/oidc/pom.xml
+++ b/examples/microprofile/oidc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/security/pom.xml
+++ b/examples/microprofile/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/static-content/pom.xml
+++ b/examples/microprofile/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/tls/pom.xml
+++ b/examples/microprofile/tls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/microprofile/websocket/pom.xml
+++ b/examples/microprofile/websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/openapi-tools/quickstart-mp/mp-client/pom.xml
+++ b/examples/openapi-tools/quickstart-mp/mp-client/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>openapi-mp-client</artifactId>

--- a/examples/openapi-tools/quickstart-mp/mp-server/pom.xml
+++ b/examples/openapi-tools/quickstart-mp/mp-server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>openapi-mp-server</artifactId>

--- a/examples/openapi-tools/quickstart-se/se-client/pom.xml
+++ b/examples/openapi-tools/quickstart-se/se-client/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>openapi-se-client</artifactId>

--- a/examples/openapi-tools/quickstart-se/se-server/pom.xml
+++ b/examples/openapi-tools/quickstart-se/se-server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>org.openapitools</groupId>

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -26,7 +26,7 @@
     <name>Helidon Standalone Quickstart MP Example</name>
 
     <properties>
-        <helidon.version>3.2.6-SNAPSHOT</helidon.version>
+        <helidon.version>3.2.7-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.microprofile.cdi.Main</mainClass>
 
         <maven.compiler.source>17</maven.compiler.source>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -26,7 +26,7 @@
     <name>Helidon Standalone Quickstart SE Example</name>
 
     <properties>
-        <helidon.version>3.2.6-SNAPSHOT</helidon.version>
+        <helidon.version>3.2.7-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.examples.quickstart.se.Main</mainClass>
 
         <maven.compiler.source>17</maven.compiler.source>

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/basic-auth-with-static-content/pom.xml
+++ b/examples/security/basic-auth-with-static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/google-login/pom.xml
+++ b/examples/security/google-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/jersey/pom.xml
+++ b/examples/security/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/nohttp-programmatic/pom.xml
+++ b/examples/security/nohttp-programmatic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/outbound-override/pom.xml
+++ b/examples/security/outbound-override/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/spi-examples/pom.xml
+++ b/examples/security/spi-examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/vaults/pom.xml
+++ b/examples/security/vaults/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-digest-auth/pom.xml
+++ b/examples/security/webserver-digest-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-signatures/pom.xml
+++ b/examples/security/webserver-signatures/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/todo-app/backend/pom.xml
+++ b/examples/todo-app/backend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.todos</groupId>

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.todo</groupId>

--- a/examples/todo-app/pom.xml
+++ b/examples/todo-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/translator-app/backend/pom.xml
+++ b/examples/translator-app/backend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>

--- a/examples/translator-app/frontend/pom.xml
+++ b/examples/translator-app/frontend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>

--- a/examples/webclient/standalone/pom.xml
+++ b/examples/webclient/standalone/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/basics/pom.xml
+++ b/examples/webserver/basics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/comment-aas/pom.xml
+++ b/examples/webserver/comment-aas/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/fault-tolerance/pom.xml
+++ b/examples/webserver/fault-tolerance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/jersey/pom.xml
+++ b/examples/webserver/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/multiport/pom.xml
+++ b/examples/webserver/multiport/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/mutual-tls/pom.xml
+++ b/examples/webserver/mutual-tls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/opentracing/pom.xml
+++ b/examples/webserver/opentracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/static-content/pom.xml
+++ b/examples/webserver/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/streaming/pom.xml
+++ b/examples/webserver/streaming/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/threadpool/pom.xml
+++ b/examples/webserver/threadpool/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/tls/pom.xml
+++ b/examples/webserver/tls/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/tutorial/pom.xml
+++ b/examples/webserver/tutorial/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/websocket/pom.xml
+++ b/examples/webserver/websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-dependencies</artifactId>
-        <version>3.2.6-SNAPSHOT</version>
+        <version>3.2.7-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>
@@ -61,7 +61,7 @@
         <version.java>17</version.java>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <helidon.version>3.2.6-SNAPSHOT</helidon.version>
+        <helidon.version>3.2.7-SNAPSHOT</helidon.version>
 
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Medium</spotbugs.threshold>


### PR DESCRIPTION
Helidon 3.2.6 was released last week and  https://github.com/helidon-io/helidon/tree/helidon-3.x  has been updated to   3.2.7-SNAPSHOT. This PR updates dev-3.x to use that Helidon version.
