### PR TITLE
/webclient/standalone example builds OK but running the separate client as in the README.md fails

### DIFF
--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public final class ServerMain {
      * @param args starting arguments
      */
     public static void main(String[] args) {
-        startServer();
+        startServer().await();
     }
 
     /**


### PR DESCRIPTION
fixes #37