### PR TITLE
3.x: Handle TMPDIR not being set

### DIFF
--- a/etc/scripts/updatehelidonversion.sh
+++ b/etc/scripts/updatehelidonversion.sh
@@ -29,6 +29,10 @@ if [ -z "${NEW_VERSION}" ]; then
     exit 1
 fi
 
+if [ -z "${TMPDIR}" ]; then
+  readonly TMPDIR="/tmp"
+fi
+
 readonly POM_FILES=$(find . -name pom.xml -print)
 
 for f in ${POM_FILES}; do

--- a/etc/scripts/updatehelidonversion.sh
+++ b/etc/scripts/updatehelidonversion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash 
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix the `updatehelidonversion.sh` script to handle when TMPDIR is not set.
