### PR TITLE
Exclude status example test for status 171 depending on JDK version

### DIFF
--- a/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusTest.java
+++ b/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,10 @@ public class StatusTest {
 
     @Test
     void checkStatusMetrics() {
-        checkAfterStatus(171);
+        // intermediate responses are not "full" responses and since JDK 20 they are not returned by the client at all
+        if (Runtime.version().feature() < 20) {
+            checkAfterStatus(171);
+        }
         checkAfterStatus(200);
         checkAfterStatus(201);
         checkAfterStatus(204);


### PR DESCRIPTION
Resolves https://github.com/helidon-io/helidon/issues/8834

As @tomas-langer noted

https://github.com/helidon-io/helidon/blob/966c7f3d02f8cdbb706f76fb7fb9614f8ea1c4bc/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusTest.java#L58-L59

the offending test request does not work with JDK 20 and higher.

This PR adds a bit of logic to retrieve the current JDK version and exclude the offending request for JDK 20 and higher.

With that change, the test works correctly with JDK 17 and 21.