### PR TITLE
3.x backport stray fixes

### DIFF
--- a/etc/scripts/updatehelidonversion.sh
+++ b/etc/scripts/updatehelidonversion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash 
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ readonly SCRIPT_DIR=$(dirname ${SCRIPT_PATH})
 if [ -z "${NEW_VERSION}" ]; then
     echo "usage: $0 <new-helidon-version>"
     exit 1
+fi
+
+if [ -z "${TMPDIR}" ]; then
+  readonly TMPDIR="/tmp"
 fi
 
 readonly POM_FILES=$(find . -name pom.xml -print)

--- a/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusTest.java
+++ b/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,10 @@ public class StatusTest {
 
     @Test
     void checkStatusMetrics() {
-        checkAfterStatus(171);
+        // intermediate responses are not "full" responses and since JDK 20 they are not returned by the client at all
+        if (Runtime.version().feature() < 20) {
+            checkAfterStatus(171);
+        }
         checkAfterStatus(200);
         checkAfterStatus(201);
         checkAfterStatus(204);


### PR DESCRIPTION
We had two PRs that were mistakenly merged  into the `helidon-3.x` branch:

* #58
* #48 

This ports those fixes into the `dev-3.x` branch so we don't loose them.

