### PR TITLE
Fix update version awk shebang

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4.1.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4.1.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}

--- a/etc/scripts/checkstyle.sh
+++ b/etc/scripts/checkstyle.sh
@@ -20,19 +20,19 @@ set -o errtrace || true # trace ERR through commands and functions
 set -o errexit || true  # exit the script if any statement returns a non-true return value
 
 on_error(){
-    CODE="${?}" && \
-    set +x && \
-    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
-        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
 }
 trap on_error ERR
 
 # Path to this script
 if [ -h "${0}" ] ; then
-    SCRIPT_PATH="$(readlink "${0}")"
+  SCRIPT_PATH="$(readlink "${0}")"
 else
-    # shellcheck disable=SC155
-    SCRIPT_PATH="${0}"
+  # shellcheck disable=SC155
+  SCRIPT_PATH="${0}"
 fi
 readonly SCRIPT_PATH
 
@@ -54,10 +54,10 @@ rm -f "${WS_DIR}"/target/checkstyle-*
 
 # shellcheck disable=SC2086
 mvn ${MAVEN_ARGS} checkstyle:checkstyle-aggregate \
-    -f "${WS_DIR}"/pom.xml \
-    -Dcheckstyle.output.format="plain" \
-    -Dcheckstyle.output.file="${RESULT_FILE}" \
-    > ${LOG_FILE} 2>&1 || (cat ${LOG_FILE} ; exit 1)
+  -f "${WS_DIR}"/pom.xml \
+  -Dcheckstyle.output.format="plain" \
+  -Dcheckstyle.output.file="${RESULT_FILE}" \
+  > ${LOG_FILE} 2>&1 || (cat ${LOG_FILE} ; exit 1)
 
 grep "^\[ERROR\]" "${RESULT_FILE}" \
-    && die "CHECKSTYLE ERROR" || echo "CHECKSTYLE OK"
+  && die "CHECKSTYLE ERROR" || echo "CHECKSTYLE OK"

--- a/etc/scripts/copyright.sh
+++ b/etc/scripts/copyright.sh
@@ -20,18 +20,18 @@ set -o errtrace || true # trace ERR through commands and functions
 set -o errexit || true  # exit the script if any statement returns a non-true return value
 
 on_error(){
-    CODE="${?}" && \
-    set +x && \
-    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
-        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
 }
 trap on_error ERR
 
 # Path to this script
 if [ -h "${0}" ] ; then
-    SCRIPT_PATH="$(readlink "${0}")"
+  SCRIPT_PATH="$(readlink "${0}")"
 else
-    SCRIPT_PATH="${0}"
+  SCRIPT_PATH="${0}"
 fi
 readonly SCRIPT_PATH
 
@@ -50,12 +50,12 @@ die() { echo "${1}" ; exit 1 ;}
 
 # shellcheck disable=SC2086
 mvn ${MAVEN_ARGS} \
-    -N -f ${WS_DIR}/pom.xml \
-    -Dhelidon.enforcer.output.file="${RESULT_FILE}" \
-    -Dhelidon.enforcer.rules=copyright \
-    -Dhelidon.enforcer.failOnError=false \
-    -Pcopyright \
-    validate > ${LOG_FILE} 2>&1 || (cat ${LOG_FILE} ; exit 1)
+  -N -f ${WS_DIR}/pom.xml \
+  -Dhelidon.enforcer.output.file="${RESULT_FILE}" \
+  -Dhelidon.enforcer.rules=copyright \
+  -Dhelidon.enforcer.failOnError=false \
+  -Pcopyright \
+  validate > ${LOG_FILE} 2>&1 || (cat ${LOG_FILE} ; exit 1)
 
 grep "^\[ERROR\]" "${RESULT_FILE}" \
-    && die "COPYRIGHT ERROR" || echo "COPYRIGHT OK"
+  && die "COPYRIGHT ERROR" || echo "COPYRIGHT OK"

--- a/etc/scripts/dependency-check.sh
+++ b/etc/scripts/dependency-check.sh
@@ -21,10 +21,10 @@ set -o errexit || true  # exit the script if any statement returns a non-true re
 
 # Path to this script
 if [ -h "${0}" ] ; then
-    SCRIPT_PATH="$(readlink "${0}")"
+  SCRIPT_PATH="$(readlink "${0}")"
 else
-    # shellcheck disable=SC155
-    SCRIPT_PATH="${0}"
+  # shellcheck disable=SC155
+  SCRIPT_PATH="${0}"
 fi
 readonly SCRIPT_PATH
 
@@ -33,10 +33,10 @@ readonly SCRIPT_PATH
 WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 
 on_error(){
-    CODE="${?}" && \
-    set +x && \
-    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
-        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
 }
 trap on_error ERR
 

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -20,19 +20,19 @@ set -o errtrace || true # trace ERR through commands and functions
 set -o errexit || true  # exit the script if any statement returns a non-true return value
 
 on_error(){
-    CODE="${?}" && \
-    set +x && \
-    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
-        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
 }
 trap on_error ERR
 
 # Path to this script
 if [ -h "${0}" ] ; then
-    SCRIPT_PATH="$(readlink "${0}")"
+  SCRIPT_PATH="$(readlink "${0}")"
 else
-    # shellcheck disable=SC155
-    SCRIPT_PATH="${0}"
+  # shellcheck disable=SC155
+  SCRIPT_PATH="${0}"
 fi
 readonly SCRIPT_PATH
 
@@ -52,33 +52,33 @@ readonly HELIDON_VERSION
 echo "HELIDON_VERSION=${HELIDON_VERSION}"
 
 release_build(){
-    echo "Starting release build for ${HELIDON_VERSION}"
+  echo "Starting release build for ${HELIDON_VERSION}"
 
-    # Branch we will push this release to
-    local LATEST_BRANCH="helidon-4.x"
+  # Branch we will push this release to
+  local LATEST_BRANCH="helidon-4.x"
 
-    if [[ ${HELIDON_VERSION} == *-SNAPSHOT ]]; then
-        echo "Helidon version ${HELIDON_VERSION} is a SNAPSHOT version and not a released version. Failing release."
-        exit 1
-    fi
+  if [[ ${HELIDON_VERSION} == *-SNAPSHOT ]]; then
+    echo "Helidon version ${HELIDON_VERSION} is a SNAPSHOT version and not a released version. Failing release."
+    exit 1
+  fi
 
-    # Merge this branch (based on dev-4.x) with the
-    # helidon-4.x branch to ensure helidon-4.x has
-    # valid history when we push all this to it.
-    git fetch origin
-    git merge -s ours --no-ff origin/${LATEST_BRANCH}
+  # Merge this branch (based on dev-4.x) with the
+  # helidon-4.x branch to ensure helidon-4.x has
+  # valid history when we push all this to it.
+  git fetch origin
+  git merge -s ours --no-ff origin/${LATEST_BRANCH}
 
-    # Create and push a git tag
-    git tag -f "${HELIDON_VERSION}"
-    git push --force origin refs/tags/"${HELIDON_VERSION}":refs/tags/"${HELIDON_VERSION}"
+  # Create and push a git tag
+  git tag -f "${HELIDON_VERSION}"
+  git push --force origin refs/tags/"${HELIDON_VERSION}":refs/tags/"${HELIDON_VERSION}"
 
-    # Update helidon-4.x branch with this release
-    git push origin HEAD:${LATEST_BRANCH}
+  # Update helidon-4.x branch with this release
+  git push origin HEAD:${LATEST_BRANCH}
 
-    echo "======================"
-    echo "Created tag:    ${HELIDON_VERSION}"
-    echo "Updated branch: ${LATEST_BRANCH}"
-    echo "======================"
+  echo "======================"
+  echo "Created tag:    ${HELIDON_VERSION}"
+  echo "Updated branch: ${LATEST_BRANCH}"
+  echo "======================"
 }
 
 release_build

--- a/etc/scripts/shellcheck.sh
+++ b/etc/scripts/shellcheck.sh
@@ -27,13 +27,13 @@ readonly CACHE_DIR
 # Caching the shellcheck
 mkdir -p "${CACHE_DIR}"
 if [ ! -e "${CACHE_DIR}/${VERSION}/shellcheck" ] ; then
-    ARCH=$(uname -m | tr "[:upper:]" "[:lower:]")
-    PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
-    curl -Lso "${CACHE_DIR}/sc.tar.xz" "${BASE_URL}/v${VERSION}/shellcheck-v${VERSION}.${PLATFORM}.${ARCH}.tar.xz"
-    tar -xf "${CACHE_DIR}/sc.tar.xz" -C "${CACHE_DIR}"
-    mkdir "${CACHE_DIR}/${VERSION}"
-    mv "${CACHE_DIR}/shellcheck-v${VERSION}/shellcheck" "${CACHE_DIR}/${VERSION}/shellcheck"
-    rm -rf "${CACHE_DIR}/shellcheck-v${VERSION}" "${CACHE_DIR}/sc.tar.xz"
+  ARCH=$(uname -m | tr "[:upper:]" "[:lower:]")
+  PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
+  curl -Lso "${CACHE_DIR}/sc.tar.xz" "${BASE_URL}/v${VERSION}/shellcheck-v${VERSION}.${PLATFORM}.${ARCH}.tar.xz"
+  tar -xf "${CACHE_DIR}/sc.tar.xz" -C "${CACHE_DIR}"
+  mkdir "${CACHE_DIR}/${VERSION}"
+  mv "${CACHE_DIR}/shellcheck-v${VERSION}/shellcheck" "${CACHE_DIR}/${VERSION}/shellcheck"
+  rm -rf "${CACHE_DIR}/shellcheck-v${VERSION}" "${CACHE_DIR}/sc.tar.xz"
 fi
 export PATH="${CACHE_DIR}/${VERSION}:${PATH}"
 
@@ -43,11 +43,11 @@ shellcheck --version
 status_code=0
 # shellcheck disable=SC2044
 for file in $(find . -name "*.sh") ; do
-    # only check tracked files
-    if git ls-files --error-unmatch "${file}" > /dev/null 2>&1 ; then
-      printf "\n-- Checking file:  %s --\n" "${file}"
-      shellcheck "${file}" || status_code=${?}
-    fi
+  # only check tracked files
+  if git ls-files --error-unmatch "${file}" > /dev/null 2>&1 ; then
+    printf "\n-- Checking file:  %s --\n" "${file}"
+    shellcheck "${file}" || status_code=${?}
+  fi
 done
 
 exit ${status_code}

--- a/etc/scripts/spotbugs.sh
+++ b/etc/scripts/spotbugs.sh
@@ -20,19 +20,19 @@ set -o errtrace || true # trace ERR through commands and functions
 set -o errexit || true  # exit the script if any statement returns a non-true return value
 
 on_error(){
-    CODE="${?}" && \
-    set +x && \
-    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
-        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
 }
 trap on_error ERR
 
 # Path to this script
 if [ -h "${0}" ] ; then
-    SCRIPT_PATH="$(readlink "${0}")"
+  SCRIPT_PATH="$(readlink "${0}")"
 else
-    # shellcheck disable=SC155
-    SCRIPT_PATH="${0}"
+  # shellcheck disable=SC155
+  SCRIPT_PATH="${0}"
 fi
 readonly SCRIPT_PATH
 

--- a/etc/scripts/update-version.awk
+++ b/etc/scripts/update-version.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/env awk -f
+#!/usr/bin/env -S awk -f
 #
 # Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #


### PR DESCRIPTION
Use
```shell
#!/usr/bin/env -S awk -f
```

Instead of:
```
#!/usr/bin/env awk -f
```

Otherwise the following error occurs on Linux:
```
/usr/bin/env: use -[v]S to pass options in shebang lines
```

This is a difference between BSD and Linux, using `-S` works on both.

| The -S/--split-string option enables use of multiple arguments on the first line of scripts (the shebang line, ‘#!’).

See https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html