### PR TITLE
4.x: Change bind-address to host in socket configuration in multiport example

### DIFF
--- a/examples/webserver/multiport/src/main/resources/application.yaml
+++ b/examples/webserver/multiport/src/main/resources/application.yaml
@@ -19,10 +19,10 @@ server:
   sockets:
     - name: "private"
       port: 8081
-      bind-address: "localhost"
+      host: "localhost"
     - name: "admin"
       port: 8082
-      bind-address: "localhost"
+      host: "localhost"
   features:
     observe:
       sockets: "admin"


### PR DESCRIPTION
Change bind-address to host in socket configuration in multiport example