### PR TITLE
4.x: Use HelidonConsoleHandler more consistently

### DIFF
--- a/examples/media/form/src/main/resources/logging.properties
+++ b/examples/media/form/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,10 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserver.level=INFO
+io.helidon.level=INFO

--- a/examples/media/multipart/src/main/resources/logging.properties
+++ b/examples/media/multipart/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,10 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserver.level=INFO
+io.helidon.level=INFO

--- a/examples/microprofile/oidc/pom.xml
+++ b/examples/microprofile/oidc/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>helidon-microprofile-oidc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>

--- a/examples/microprofile/oidc/src/main/resources/logging.properties
+++ b/examples/microprofile/oidc/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
 # limitations under the License.
 #
 
-handlers = java.util.logging.ConsoleHandler
-
-java.util.logging.ConsoleHandler.level = FINEST
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format = [%1$tc] %4$s: %2$s - %5$s %6$s%n
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
 
 .level = INFO
 io.helidon.config.level = WARNING
@@ -26,3 +23,6 @@ io.helidon.config.level = WARNING
 AUDIT.level=FINEST
 # to see detailed information about failed validations of tokens
 io.helidon.security.providers.oidc.level=FINEST
+
+# Quiet Weld
+org.jboss.level=WARNING

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,13 @@
 # limitations under the License.
 #
 
-# Example Logging Configuration File
-# For more information see $JAVA_HOME/jre/lib/logging.properties
-
-# Send messages to the console
 handlers=io.helidon.logging.jul.HelidonConsoleHandler
-
-# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
 
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
+io.helidon.level=INFO
 
 # Quiet Weld
 org.jboss.level=WARNING
-
-# Component specific log levels
-#io.helidon.webserver.level=INFO
-#io.helidon.config.level=INFO
-#io.helidon.security.level=INFO
-#io.helidon.microprofile.level=INFO
-#io.helidon.common.level=INFO
-#org.glassfish.jersey.level=INFO
-#org.jboss.weld=INFO

--- a/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
 #
 
 handlers=io.helidon.logging.jul.HelidonConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
 
 # Global logging level. Can be overridden by specific loggers
 .level=INFO

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <helidon.version>4.2.0-SNAPSHOT</helidon.version>
-        <mainClass>io.helidon.microprofile.cdi.Main</mainClass>
+        <mainClass>io.helidon.Main</mainClass>
 
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,25 +14,13 @@
 # limitations under the License.
 #
 
-# Example Logging Configuration File
-# For more information see $JAVA_HOME/jre/lib/logging.properties
-
-## Send messages to the console
 handlers=io.helidon.logging.jul.HelidonConsoleHandler
-#
-## HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-#
-## Global logging level. Can be overridden by specific loggers
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
 .level=INFO
+io.helidon.level=INFO
 
 # Quiet Weld
 org.jboss.level=WARNING
-
-# Component specific log levels
-#io.helidon.webserver.level=INFO
-#io.helidon.config.level=INFO
-#io.helidon.security.level=INFO
-#io.helidon.microprofile.level=INFO
-#io.helidon.common.level=INFO
-#org.jboss.weld=INFO

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
 
 # Global logging level. Can be overridden by specific loggers
 .level=INFO

--- a/examples/security/outbound-override/pom.xml
+++ b/examples/security/outbound-override/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>helidon-bundles-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideExample.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.logging.common.LogConfig;
 import io.helidon.security.Principal;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.Subject;
@@ -48,6 +49,10 @@ public final class OutboundOverrideExample {
      * @param args ignored
      */
     public static void main(String[] args) {
+
+        // load logging configuration
+        LogConfig.configureRuntime();
+
         WebServerConfig.Builder builder = WebServer.builder();
         setup(builder);
         WebServer server = builder.build();

--- a/examples/security/outbound-override/src/main/resources/logging.properties
+++ b/examples/security/outbound-override/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-handlers = java.util.logging.ConsoleHandler
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
 
-java.util.logging.ConsoleHandler.level = FINEST
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format = [%1$tc] %4$s: %2$s - %5$s %6$s%n
-
-.level = INFO
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+io.helidon.level=INFO

--- a/examples/webserver/basic/pom.xml
+++ b/examples/webserver/basic/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/examples/webserver/basic/src/main/java/io/helidon/examples/webserver/basic/BasicMain.java
+++ b/examples/webserver/basic/src/main/java/io/helidon/examples/webserver/basic/BasicMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.examples.webserver.basic;
 
+import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 
@@ -32,6 +33,10 @@ public class BasicMain {
      * @param args ignored
      */
     public static void main(String[] args) {
+
+        // load logging configuration
+        LogConfig.configureRuntime();
+
         /*
          This would be the simplest possible server
          We do not use it, as we want testability

--- a/examples/webserver/basic/src/main/resources/logging.properties
+++ b/examples/webserver/basic/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserver.level=INFO
+io.helidon.level=INFO

--- a/examples/webserver/observe/pom.xml
+++ b/examples/webserver/observe/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/examples/webserver/observe/src/main/resources/logging.properties
+++ b/examples/webserver/observe/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserve.level=INFO
+io.helidon.level=INFO
 
-java.util.logging.ConsoleHandler.level=ALL
 # to enable security audit logging for Helidon:
 # AUDIT.level=FINEST

--- a/examples/webserver/protocols-custom/src/main/resources/logging.properties
+++ b/examples/webserver/protocols-custom/src/main/resources/logging.properties
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=ALL
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserver.level=INFO
-# io.helidon.examples.webserver.sdp.level=FINE
+io.helidon.level=INFO
+#io.helidon.examples.webserver.sdp.level=FINE

--- a/examples/webserver/protocols/pom.xml
+++ b/examples/webserver/protocols/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>helidon-webserver-http2</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/examples/webserver/protocols/src/main/resources/logging.properties
+++ b/examples/webserver/protocols/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserver.level=INFO
+io.helidon.level=INFO

--- a/examples/webserver/tracing/src/main/resources/logging.properties
+++ b/examples/webserver/tracing/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s !thread!: %5$s%6$s%n
+
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.webserver.level=INFO
+io.helidon.level=INFO


### PR DESCRIPTION

Updates examples to more consistently use `HelidonConsoleHandler`. This is not a 100% complete sweep, but addresses the primary offenders.

See #125 