### PR TITLE
4.x: minor example fixes: helidon version, jandex plugin version

### DIFF
--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ readonly WS_DIR
 mvn ${MAVEN_ARGS} --version
 
 # shellcheck disable=SC2086
-mvn ${MAVEN_ARGS} \
+mvn -B ${MAVEN_ARGS} \
     -f "${WS_DIR}"/pom.xml \
     -Dmaven.test.failure.ignore=true \
     clean install

--- a/examples/integrations/oci/genai-cdi/pom.xml
+++ b/examples/integrations/oci/genai-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.1.6</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/genai/pom.xml
+++ b/examples/integrations/oci/genai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.1.6</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/media/json-patch/pom.xml
+++ b/examples/media/json-patch/pom.xml
@@ -33,6 +33,7 @@
 
     <properties>
         <mainClass>io.helidon.examples.media.json.patch.Main</mainClass>
+        <version.plugin.jandex>${version.lib.jandex}</version.plugin.jandex>
     </properties>
 
     <dependencies>
@@ -89,6 +90,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
+                <version>${version.plugin.jandex}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/examples/media/json-patch/pom.xml
+++ b/examples/media/json-patch/pom.xml
@@ -33,7 +33,6 @@
 
     <properties>
         <mainClass>io.helidon.examples.media.json.patch.Main</mainClass>
-        <version.plugin.jandex>${version.lib.jandex}</version.plugin.jandex>
     </properties>
 
     <dependencies>
@@ -84,16 +83,6 @@
                 <executions>
                     <execution>
                         <id>copy-libs</id>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>io.smallrye</groupId>
-                <artifactId>jandex-maven-plugin</artifactId>
-                <version>${version.plugin.jandex}</version>
-                <executions>
-                    <execution>
-                        <id>make-index</id>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
1. Fix version in genai examples
2. Remove`jandex-maven-plugin` in `media/json-patch` example (which is an SE example)
3. Use -B with maven in build script