### PR TITLE
4.x: validation step to build with latest stable EA JDK

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - name: Set up JDK ${{ env.JAVA_LATEST_VERSION }}
+      - name: Set up JDK ea-stable
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -160,3 +160,28 @@ jobs:
           cache: maven
       - name: Maven build
         run: etc/scripts/build.sh
+  build-latest-java:
+    needs: prime-build
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download Maven Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: io-helidon-maven-artifacts
+          path: ~/.m2/repository/io/helidon
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Set up JDK ${{ env.JAVA_LATEST_VERSION }}
+        uses: oracle-actions/setup-java@v1
+        with:
+          website: jdk.java.net
+          release: ea
+          version: latest
+          cache: maven
+      - name: Maven build
+        run: etc/scripts/build.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -182,7 +182,6 @@ jobs:
           website: jdk.java.net
           release: ea
           version: stable
-          cache: maven
       - name: Maven build
         run: etc/scripts/build.sh
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -185,4 +185,4 @@ jobs:
       - name: Maven build
         run: etc/scripts/build.sh
         env:
-          MAVEN_ARGS: -pl '!examples/integrations/micronaut/data'
+          MAVEN_ARGS: -pl !examples/integrations/micronaut/data

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           website: jdk.java.net
           release: ea
-          version: latest
+          version: stable
           cache: maven
       - name: Maven build
         run: etc/scripts/build.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -185,3 +185,5 @@ jobs:
           cache: maven
       - name: Maven build
         run: etc/scripts/build.sh
+        env:
+          MAVEN_ARGS: -pl '!examples/integrations/micronaut/data'

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -41,6 +41,7 @@ readonly SCRIPT_PATH
 WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 readonly WS_DIR
 
+set -x
 # shellcheck disable=SC2086
 mvn ${MAVEN_ARGS} --version
 

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -41,7 +41,6 @@ readonly SCRIPT_PATH
 WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 readonly WS_DIR
 
-set -x
 # shellcheck disable=SC2086
 mvn ${MAVEN_ARGS} --version
 

--- a/examples/coherence/pom.xml
+++ b/examples/coherence/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <mainClass>io.helidon.examples.coherence.Main</mainClass>
-        <version.lib.coherence>24.03.1</version.lib.coherence>
+        <version.lib.coherence>24.09.3</version.lib.coherence>
     </properties>
 
     <dependencyManagement>

--- a/examples/microprofile/coherence/pom.xml
+++ b/examples/microprofile/coherence/pom.xml
@@ -32,7 +32,7 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <version.lib.coherence>24.03.1</version.lib.coherence>
+        <version.lib.coherence>24.09.3</version.lib.coherence>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Adds a validation step to build using the latest stable EA JDK. The intention is that this will be a non-blocking check.  We exclude the micronaut example because the version of micronaut does not work with Java 24.

Also upgrades Coherence to a version that works with Java 24.

We use the Oracle `setup-java` because it provides access to Oracle OpenJDK EA builds. The `version` parameter can be a specific EA release (like `24`) or `stable` or `latest`.  At the time of this PR `stable` is 24.  

```
      - name: Set up JDK ea-stable
        uses: oracle-actions/setup-java@v1
        with:
          website: jdk.java.net
          release: ea
          version: stable
```

