### PR TITLE
4.x: Gradle build file updates to prepare for Gradle 9

### DIFF
--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
     id 'java'
-    id 'org.kordamp.gradle.jandex' version '0.6.0'
+    id 'org.kordamp.gradle.jandex' version '2.0.0'
     id 'application'
 }
 
@@ -25,8 +25,11 @@ version = '1.0-SNAPSHOT'
 
 description = """helidon-quickstart-mp"""
 
-sourceCompatibility = 21
-targetCompatibility = 21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
@@ -52,9 +55,10 @@ dependencies {
     runtimeOnly 'jakarta.activation:jakarta.activation-api'
 
     testImplementation 'io.helidon.microprofile.testing:helidon-microprofile-testing-junit5'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.hamcrest:hamcrest-all'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {
@@ -100,7 +104,7 @@ task moveBeansXML {
                  todir: "${buildDir}/classes/java/main/META-INF"
     }
 }
-compileTestJava.dependsOn jandex
-jar.dependsOn jandex
+compileTestJava.dependsOn "jandex"
+jar.dependsOn "jandex"
 test.dependsOn moveBeansXML
 run.dependsOn moveBeansXML

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -24,8 +24,11 @@ version = '1.0-SNAPSHOT'
 
 description = """helidon-quickstart-se"""
 
-sourceCompatibility = 21
-targetCompatibility = 21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
@@ -54,10 +57,13 @@ dependencies {
     implementation 'io.helidon.config:helidon-config-yaml'
     implementation 'io.helidon.health:helidon-health-checks'
 
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'io.helidon.webserver.testing.junit5:helidon-webserver-testing-junit5'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'io.helidon.webclient:helidon-webclient'
     testImplementation 'org.hamcrest:hamcrest-all'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 // define a custom task to copy all dependencies in the runtime classpath


### PR DESCRIPTION
Fixes #143 

1. Updates jandex plugin to 2.0.0
2. Uses explicit syntax for java compiler properties
3. Explicit adds some test dependencies that were (apparently) previously infered
4. Make jandex task name explicitly a string