### PR TITLE
4.x: Free up disk space on builds

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,6 +144,12 @@ jobs:
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     steps:
+      - if: runner.os == 'Linux'
+        name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/share/powershell
       - name: Download Maven Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -168,6 +174,12 @@ jobs:
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     steps:
+      - if: runner.os == 'Linux'
+        name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/share/powershell
       - name: Download Maven Artifacts
         uses: actions/download-artifact@v4
         with:

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -48,4 +48,4 @@ mvn ${MAVEN_ARGS} --version
 mvn -B ${MAVEN_ARGS} \
     -f "${WS_DIR}"/pom.xml \
     -Dmaven.test.failure.ignore=true \
-    clean install
+    clean package


### PR DESCRIPTION
1. Updates pipeline to free up diskspace on builds.
2. Changes build script to use package and not install (saves a few MB of disk)

