### PR TITLE
Updates example to use the new grpc-reflection feature

### DIFF
--- a/examples/webserver/grpc/README.md
+++ b/examples/webserver/grpc/README.md
@@ -9,6 +9,11 @@ The gRPC service definition is found in the `strings.proto` file which is compil
 using `protoc` at build time. The Strings service includes all 4 types of methods:
 unary, client streaming, server streaming and bidirectional.
 
+This example also enables the `grpc-reflection` feature to expose the Helidon
+gRPC reflection service. This service answers reflection queries so that clients
+that support [this protocol](https://grpc.io/docs/guides/reflection/) can interact 
+with the _Strings_ service without having access to the `strings.proto` file.
+
 ## Build and run tests
 
 ```shell
@@ -20,3 +25,23 @@ mvn package
 ```shell
 java -jar target/helidon-examples-webserver-grpc.jar
 ```
+
+## Testing the app using `grpcurl`
+
+With the gRPC reflection feature enabled:
+
+```shell
+>> grpcurl -insecure -d '{ "text": "hello world" }' localhost:8080 StringService.Split
+{
+  "text": "hello"
+}
+{
+  "text": "world"
+}
+```
+
+Note that the `-proto` parameter of `grpcurl` is not required in this
+example (see `grpc-reflection` feature in `application.yaml`). The `-insecure` option 
+is necessary to skip certificate and domain verification given the use of self-signed
+certificates in this example.
+

--- a/examples/webserver/grpc/pom.xml
+++ b/examples/webserver/grpc/pom.xml
@@ -138,8 +138,7 @@
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${version.lib.google-protobuf}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${version.lib.grpc}:exe:${os.detected.classifier}
-                    </pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${version.lib.grpc}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/webserver/grpc/src/main/resources/application.yaml
+++ b/examples/webserver/grpc/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ server:
         resource:
           resource-path: "server.p12"
   features:
+    grpc-reflection:
+      enabled: true
     observe:
       observers:
         health:


### PR DESCRIPTION
Updates example to use the new `grpc-reflection` feature. Adds section to README.md file to show how to use this new feature using `grpcurl`.

Depends on https://github.com/helidon-io/helidon/pull/10014.