### PR TITLE
4.x upgrade setup-java to 4.7.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             token: ${{ secrets.SERVICE_ACCOUNT_TOKEN }}
             fetch-depth: '0'
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -78,7 +78,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -99,7 +99,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -129,7 +129,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -159,7 +159,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}


### PR DESCRIPTION

Upgrades setup-java to 4.7.1.

Should resolve caching issues in validation workflow that were reporting:

```
Failed to restore: Cache service responded with 422
```

and resulting in copyright check failing.
