### PR TITLE
4.x: path pattern for any subpath using the Helidon 4 way

### DIFF
--- a/examples/microprofile/idcs/src/main/resources/application.yaml
+++ b/examples/microprofile/idcs/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ security:
           identity-uri: "${security.properties.idcs-uri}"
   web-server:
     paths:
-      - path: "/web[/{*}]"
+      - path: "/web/*"
         authenticate: true
-      - path: "/service[/{*}]"
+      - path: "/service/*"
         authenticate: true

--- a/examples/microprofile/security/src/main/resources/application.yaml
+++ b/examples/microprofile/security/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,5 +36,5 @@ security:
         password: "changeit"
   web-server:
     paths:
-    - path: "/static-cp[/{*}]"
+    - path: "/static-cp/*"
       authenticate: true

--- a/examples/security/attribute-based-access-control/src/main/resources/application.yaml
+++ b/examples/security/attribute-based-access-control/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ security:
       - path: "/noRoles"
         methods: ["get"]
         authenticate: true
-      - path: "/user[/{*}]"
+      - path: "/user/*"
         methods: ["get"]
         # implies authentication and authorization
         abac:

--- a/examples/security/basic-auth-with-static-content/src/main/java/io/helidon/examples/security/basicauth/BasicExampleBuilderMain.java
+++ b/examples/security/basic-auth-with-static-content/src/main/java/io/helidon/examples/security/basicauth/BasicExampleBuilderMain.java
@@ -107,9 +107,9 @@ public final class BasicExampleBuilderMain {
                                     .build())
                 .routing(routing -> routing
                 // must be configured first, to protect endpoints
-                .any("/static[/{*}]", SecurityFeature.rolesAllowed("user"))
+                .any("/static/*", SecurityFeature.rolesAllowed("user"))
                 .get("/noRoles", SecurityFeature.enforce())
-                .get("/user[/{*}]", SecurityFeature.rolesAllowed("user"))
+                .get("/user/*", SecurityFeature.rolesAllowed("user"))
                 .get("/admin", SecurityFeature.rolesAllowed("admin"))
                 // audit is not enabled for GET methods by default
                 .get("/deny", SecurityFeature.rolesAllowed("deny").audit())
@@ -117,7 +117,7 @@ public final class BasicExampleBuilderMain {
                 .any("/noAuthn", SecurityFeature.rolesAllowed("admin")
                         .authenticationOptional()
                         .audit())
-                .get("/{*}", (req, res) -> {
+                .get("/*", (req, res) -> {
                     Optional<SecurityContext> securityContext = req.context().get(SecurityContext.class);
                     res.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);
                     res.send("Hello, you are: \n" + securityContext

--- a/examples/security/basic-auth-with-static-content/src/main/java/io/helidon/examples/security/basicauth/BasicExampleConfigMain.java
+++ b/examples/security/basic-auth-with-static-content/src/main/java/io/helidon/examples/security/basicauth/BasicExampleConfigMain.java
@@ -86,7 +86,7 @@ public final class BasicExampleConfigMain {
                                             .welcome("index.html"))
                                     .build())
                 .routing(routing -> routing
-                        .get("/{*}", (req, res) -> {
+                        .get("/*", (req, res) -> {
                             Optional<SecurityContext> securityContext = req.context().get(SecurityContext.class);
                             res.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);
                             res.send("Hello, you are: \n" + securityContext

--- a/examples/security/basic-auth-with-static-content/src/main/resources/application.yaml
+++ b/examples/security/basic-auth-with-static-content/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ server:
       paths:
         - path: "/noRoles"
           methods: [ "get" ]
-        - path: "/user[/{*}]"
+        - path: "/user/*"
           methods: [ "get" ]
           roles-allowed: [ "user" ]
         - path: "/admin"
@@ -40,7 +40,7 @@ server:
           roles-allowed: [ "admin" ]
           authentication-optional: true
           audit: true
-        - path: "/static[/{*}]"
+        - path: "/static/*"
           roles-allowed: "user"
 
 security:

--- a/examples/security/webserver-digest-auth/src/main/java/io/helidon/examples/security/digest/DigestExampleBuilderMain.java
+++ b/examples/security/webserver-digest-auth/src/main/java/io/helidon/examples/security/digest/DigestExampleBuilderMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public final class DigestExampleBuilderMain {
                                     .build())
                 .routing(routing -> routing
                 .get("/noRoles", SecurityFeature.enforce())
-                .get("/user[/{*}]", SecurityFeature.rolesAllowed("user"))
+                .get("/user/*", SecurityFeature.rolesAllowed("user"))
                 .get("/admin", SecurityFeature.rolesAllowed("admin"))
                 // audit is not enabled for GET methods by default
                 .get("/deny", SecurityFeature.rolesAllowed("deny").audit())
@@ -113,7 +113,7 @@ public final class DigestExampleBuilderMain {
                 .any("/noAuthn", SecurityFeature.rolesAllowed("admin")
                         .authenticationOptional()
                         .audit())
-                .get("/{*}", (req, res) -> {
+                .get("/*", (req, res) -> {
                     Optional<SecurityContext> securityContext = req.context().get(SecurityContext.class);
                     res.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);
                     res.send("Hello, you are: \n" + securityContext

--- a/examples/security/webserver-digest-auth/src/main/java/io/helidon/examples/security/digest/DigestExampleConfigMain.java
+++ b/examples/security/webserver-digest-auth/src/main/java/io/helidon/examples/security/digest/DigestExampleConfigMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public final class DigestExampleConfigMain {
         server.config(config.get("server"))
                 .routing(routing -> routing
                 // web server does not (yet) have possibility to configure routes in config files, so explicit...
-                .get("/{*}", (req, res) -> {
+                .get("/*", (req, res) -> {
                     Optional<SecurityContext> securityContext = req.context().get(SecurityContext.class);
                     res.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);
                     res.send("Hello, you are: \n" + securityContext

--- a/examples/security/webserver-digest-auth/src/main/resources/application.yaml
+++ b/examples/security/webserver-digest-auth/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2016, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ server:
       paths:
         - path: "/noRoles"
           methods: [ "get" ]
-        - path: "/user[/{*}]"
+        - path: "/user/*"
           methods: [ "get" ]
           roles-allowed: [ "user" ]
         - path: "/admin"

--- a/examples/security/webserver-signatures/src/main/java/io/helidon/examples/security/signatures/Service2.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/examples/security/signatures/Service2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ class Service2 implements HttpService {
 
     @Override
     public void routing(HttpRules rules) {
-        rules.get("/{*}", this::handle);
+        rules.get("/*", this::handle);
     }
 
     private void handle(ServerRequest req, ServerResponse res) {


### PR DESCRIPTION
Updated examples to use the new `/*` pattern for "any subpath" instead of the old, more convoluted one (`[/{*}]`)

Resolves #159 
Related to https://github.com/helidon-io/helidon/issues/10159