### PR TITLE
Updates MP example to showcase the use of the gRPC reflection service

### DIFF
--- a/examples/microprofile/grpc/README.md
+++ b/examples/microprofile/grpc/README.md
@@ -7,9 +7,33 @@ This examples shows a simple application written using Helidon gRPC MP API:
 - StringServiceTest: a sample test that starts a server and tests the client and server components
 - application.yaml: configuration for server and client channels
 
-## Build and run
+## Build and run tests
 
 ```shell
 mvn package
-java -jar target/helidon-examples-microprofile-grpc.jar 
 ```
+
+## Run the app
+
+```shell
+java -jar target/helidon-examples-microprofile-grpc.jar
+```
+
+## Testing the app using `grpcurl`
+
+With the gRPC reflection feature enabled:
+
+```shell
+>> grpcurl -insecure -d '{ "text": "hello world" }' localhost:8080 StringService.Split
+{
+  "text": "hello"
+}
+{
+  "text": "world"
+}
+```
+
+Note that the `-proto` parameter of `grpcurl` is not required in this
+example (see `grpc-reflection` feature in `application.yaml`). The `-insecure` option
+is necessary to skip certificate and domain verification given the use of self-signed
+certificates in this example.

--- a/examples/microprofile/grpc/src/main/java/io/helidon/examples/microprofile/grpc/StringService.java
+++ b/examples/microprofile/grpc/src/main/java/io/helidon/examples/microprofile/grpc/StringService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import io.helidon.grpc.api.Grpc;
 import io.helidon.grpc.core.CollectingObserver;
 
+import com.google.protobuf.Descriptors;
 import io.grpc.stub.StreamObserver;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -31,6 +32,16 @@ import jakarta.enterprise.context.ApplicationScoped;
 @Grpc.GrpcService
 @ApplicationScoped
 public class StringService {
+
+    /**
+     * Make the proto available to Helidon for gRPC reflection.
+     *
+     * @return the proto file descriptor
+     */
+    @Grpc.Proto
+    public Descriptors.FileDescriptor proto() {
+        return Strings.getDescriptor();
+    }
 
     /**
      * Uppercase a string.

--- a/examples/microprofile/grpc/src/main/resources/application.yaml
+++ b/examples/microprofile/grpc/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 server:
-  port: 0
+  port: 8080
   tls:
     trust:
       keystore:
@@ -28,6 +28,9 @@ server:
         passphrase: "password"
         resource:
           resource-path: "server.p12"
+  features:
+    grpc-reflection:
+      enabled: true
 
 grpc:
   client:


### PR DESCRIPTION
Updates example to showcase the use of the gRPC reflection service in an MP app. Extends README.md explaining how to use grpcurl.