### PR TITLE
New example for JSON-RPC API

### DIFF
--- a/examples/webserver/jsonrpc/README.md
+++ b/examples/webserver/jsonrpc/README.md
@@ -18,3 +18,14 @@ mvn package
 ```shell
 java -jar target/helidon-examples-webserver-jsonrpc.jar
 ```
+
+## Exercise the application
+
+```shell
+curl -X POST \
+     -H 'Content-Type: application/json' \
+     -d '{ "jsonrpc": "2.0", "id": 1, "method": "start", "params" : { "when": "NOW", "duration": "PT0S" } }' \
+     http://localhost:8080/rpc/machine
+      
+#Output: {"jsonrpc":"2.0","id":1,"result":{"status":"RUNNING"}}
+```

--- a/examples/webserver/jsonrpc/README.md
+++ b/examples/webserver/jsonrpc/README.md
@@ -1,0 +1,20 @@
+# Helidon JSON-RPC Example
+
+This example shows how to use the JSON-RPC SE API. The main class `JsonRpcMain`
+creates a routing object for JSON-RPC and a couple of methods on a _machine_
+resource. The single test class in the project uses the JSON-RPC client API
+to test the application.
+
+For more information about the protocol see the [JSON-RPC Specification](https://www.jsonrpc.org/specification).
+
+## Build and run tests
+
+```shell
+mvn package
+```
+
+## Run the app
+
+```shell
+java -jar target/helidon-examples-webserver-jsonrpc.jar
+```

--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -25,9 +25,12 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.jsonrpc</groupId>
+            <artifactId>helidon-jsonrpc-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
-            <artifactId>helidon-webserver-json-rpc</artifactId>
-            <version>${helidon.version}</version>
+            <artifactId>helidon-webserver-jsonrpc</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
@@ -62,12 +65,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
-            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <artifactId>helidon-webserver-testing-junit5-jsonrpc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
-            <artifactId>helidon-webclient-http1</artifactId>
+            <artifactId>helidon-webclient-jsonrpc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.examples.webserver</groupId>
+    <artifactId>helidon-examples-webserver-json-rpc</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Helidon Examples WebServer JSON-RPC</name>
+
+    <properties>
+        <mainClass>io.helidon.examples.webserver.jsonrpc.JsonRpcMain</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-json-rpc</artifactId>
+            <version>${helidon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jsonp</artifactId>
+        </dependency>
+        <dependency>
+            <artifactId>helidon-logging-jul</artifactId>
+            <groupId>io.helidon.logging</groupId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-http1</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -60,13 +60,12 @@
             <artifactId>helidon-http-media-jsonp</artifactId>
         </dependency>
         <dependency>
-            <artifactId>helidon-logging-jul</artifactId>
-            <groupId>io.helidon.logging</groupId>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common.features</groupId>
-            <artifactId>helidon-common-features-api</artifactId>
-            <optional>true</optional>
+            <artifactId>helidon-logging-jul</artifactId>
+            <groupId>io.helidon.logging</groupId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -86,11 +85,6 @@
         <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-jsonrpc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <groupId>io.helidon.examples.webserver</groupId>
-    <artifactId>helidon-examples-webserver-json-rpc</artifactId>
+    <artifactId>helidon-examples-webserver-jsonrpc</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>Helidon Examples WebServer JSON-RPC</name>
 

--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -17,16 +17,15 @@ package io.helidon.examples.webserver.jsonrpc;
 
 import java.time.Duration;
 
-import io.helidon.http.Status;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.jsonrpc.JsonRpcError;
 import io.helidon.webserver.jsonrpc.JsonRpcHandlers;
+import io.helidon.webserver.jsonrpc.JsonRpcRequest;
+import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.jsonrpc.JsonRpcRules;
 import io.helidon.webserver.jsonrpc.JsonRpcService;
-import io.helidon.webserver.jsonrpc.JsonRpcRequest;
-import io.helidon.webserver.jsonrpc.JsonRpcResponse;
-import io.helidon.webserver.jsonrpc.JsonRpcError;
 
 public class JsonRpcMain {
 
@@ -65,30 +64,28 @@ public class JsonRpcMain {
         void start(JsonRpcRequest req, JsonRpcResponse res) throws Exception {
             StartStopParams params = req.params().as(StartStopParams.class);
             if (params.when().equals("NOW")) {
-                res.id(req.id().orElseThrow());
                 res.result(new StartStopResult("RUNNING"));
-                res.status(Status.OK_200).send();
+                res.send();
             } else {
                 res.error(JsonRpcError.builder()
                                   .code(JsonRpcError.INVALID_PARAMS)
                                   .data(new ErrorData("Bad param"))
                                   .build());
-                res.status(Status.OK_200).send();
+                res.send();
             }
         }
 
         void stop(JsonRpcRequest req, JsonRpcResponse res) throws Exception {
             StartStopParams params = req.params().as(StartStopParams.class);
             if (params.when().equals("NOW")) {
-                res.id(req.id().orElseThrow());
                 res.result(new StartStopResult("STOPPED"));
-                res.status(Status.OK_200).send();
+                res.send();
             } else {
                 res.error(JsonRpcError.builder()
                                   .code(JsonRpcError.INVALID_PARAMS)
                                   .data(new ErrorData("Bad param"))
                                   .build());
-                res.status(Status.OK_200).send();
+                res.send();
             }
         }
 

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -70,7 +70,7 @@ public class JsonRpcMain {
                 res.status(Status.OK_200).send();
             } else {
                 res.error(JsonRpcError.builder()
-                                  .code(-32600)
+                                  .code(JsonRpcError.INVALID_PARAMS)
                                   .data(new ErrorData("Bad param"))
                                   .build());
                 res.status(Status.OK_200).send();
@@ -85,7 +85,7 @@ public class JsonRpcMain {
                 res.status(Status.OK_200).send();
             } else {
                 res.error(JsonRpcError.builder()
-                                  .code(-32600)
+                                  .code(JsonRpcError.INVALID_PARAMS)
                                   .data(new ErrorData("Bad param"))
                                   .build());
                 res.status(Status.OK_200).send();

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.webserver.jsonrpc;
+
+import java.time.Duration;
+
+import io.helidon.http.Status;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.jsonrpc.JsonRpcHandlers;
+import io.helidon.webserver.jsonrpc.JsonRpcRouting;
+import io.helidon.webserver.jsonrpc.JsonRpcRules;
+import io.helidon.webserver.jsonrpc.JsonRpcService;
+import io.helidon.webserver.jsonrpc.JsonRpcRequest;
+import io.helidon.webserver.jsonrpc.JsonRpcResponse;
+import io.helidon.webserver.jsonrpc.JsonRpcError;
+
+public class JsonRpcMain {
+
+    private JsonRpcMain() {
+    }
+
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+
+        // create JSON-RPC routing
+        JsonRpcRouting routing = JsonRpcRouting.builder()
+                .service(new JsonRpcService1())
+                .build();
+
+        // set up HTTP routing from JSON-RPC routing
+        WebServer.builder()
+                .port(8080)
+                .host("127.0.0.1")
+                .addRouting(routing.toHttpRouting())
+                .build()
+                .start();
+    }
+
+    static class JsonRpcService1 implements JsonRpcService {
+
+        @Override
+        public void routing(JsonRpcRules rules) {
+            // register a handler for each method on same path
+            rules.register("/jsonrpc",
+                           JsonRpcHandlers.builder()
+                                   .method("start", this::start)
+                                   .method("stop", this::stop)
+                                   .build());
+        }
+
+        void start(JsonRpcRequest req, JsonRpcResponse res) throws Exception {
+            StartStopParams params = req.params().as(StartStopParams.class);
+            if (params.when().equals("NOW")) {
+                res.id(req.id().orElseThrow());
+                res.result(new StartStopResult("RUNNING"));
+                res.status(Status.OK_200).send();
+            } else {
+                res.error(JsonRpcError.builder()
+                                  .code(-32600)
+                                  .data(new ErrorData("Bad param"))
+                                  .build());
+                res.status(Status.OK_200).send();
+            }
+        }
+
+        void stop(JsonRpcRequest req, JsonRpcResponse res) throws Exception {
+            StartStopParams params = req.params().as(StartStopParams.class);
+            if (params.when().equals("NOW")) {
+                res.id(req.id().orElseThrow());
+                res.result(new StartStopResult("STOPPED"));
+                res.status(Status.OK_200).send();
+            } else {
+                res.error(JsonRpcError.builder()
+                                  .code(-32600)
+                                  .data(new ErrorData("Bad param"))
+                                  .build());
+                res.status(Status.OK_200).send();
+            }
+        }
+
+        public record StartStopParams(String when, Duration duration) {
+        }
+
+        public record StartStopResult(String status) {
+        }
+
+        public record ErrorData(String reason) {
+        }
+    }
+}

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -27,11 +27,19 @@ import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.jsonrpc.JsonRpcRules;
 import io.helidon.webserver.jsonrpc.JsonRpcService;
 
+/**
+ * The JSON-RPC example main class.
+ */
 public class JsonRpcMain {
 
     private JsonRpcMain() {
     }
 
+    /**
+     * Entry point to application.
+     *
+     * @param args CLI args
+     */
     public static void main(String[] args) {
         LogConfig.configureRuntime();
 
@@ -81,9 +89,20 @@ public class JsonRpcMain {
         }
     }
 
+    /**
+     * A record representing the start/stop params.
+     *
+     * @param when time to start machine
+     * @param duration for how long
+     */
     public record StartStopParams(String when, Duration duration) {
     }
 
+    /**
+     * A record representing the start/stop result.
+     *
+     * @param status status of operation
+     */
     public record StartStopResult(String status) {
     }
 }

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
-import io.helidon.webserver.jsonrpc.JsonRpcError;
+import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webserver.jsonrpc.JsonRpcHandlers;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
@@ -36,66 +36,54 @@ public class JsonRpcMain {
         LogConfig.configureRuntime();
 
         // create JSON-RPC routing
-        JsonRpcRouting routing = JsonRpcRouting.builder()
-                .service(new JsonRpcService1())
+        JsonRpcRouting jsonRpcRouting = JsonRpcRouting.builder()
+                .service(new MachineService())
                 .build();
 
-        // set up HTTP routing from JSON-RPC routing
+        // set up HTTP routing using JSON-RPC routing
         WebServer.builder()
                 .port(8080)
                 .host("127.0.0.1")
-                .addRouting(routing.toHttpRouting())
+                .routing(jsonRpcRouting)
                 .build()
                 .start();
     }
 
-    static class JsonRpcService1 implements JsonRpcService {
+    static class MachineService implements JsonRpcService {
 
         @Override
         public void routing(JsonRpcRules rules) {
-            // register a handler for each method on same path
-            rules.register("/jsonrpc",
+            rules.register("/machine",
                            JsonRpcHandlers.builder()
-                                   .method("start", this::start)
-                                   .method("stop", this::stop)
+                                   .putMethod("start", this::start)
+                                   .putMethod("stop", this::stop)
                                    .build());
         }
 
-        void start(JsonRpcRequest req, JsonRpcResponse res) throws Exception {
+        void start(JsonRpcRequest req, JsonRpcResponse res) {
             StartStopParams params = req.params().as(StartStopParams.class);
             if (params.when().equals("NOW")) {
                 res.result(new StartStopResult("RUNNING"));
-                res.send();
             } else {
-                res.error(JsonRpcError.builder()
-                                  .code(JsonRpcError.INVALID_PARAMS)
-                                  .data(new ErrorData("Bad param"))
-                                  .build());
-                res.send();
+                res.error(JsonRpcError.INVALID_PARAMS, "Bad param");
             }
+            res.send();
         }
 
-        void stop(JsonRpcRequest req, JsonRpcResponse res) throws Exception {
+        void stop(JsonRpcRequest req, JsonRpcResponse res) {
             StartStopParams params = req.params().as(StartStopParams.class);
             if (params.when().equals("NOW")) {
                 res.result(new StartStopResult("STOPPED"));
-                res.send();
             } else {
-                res.error(JsonRpcError.builder()
-                                  .code(JsonRpcError.INVALID_PARAMS)
-                                  .data(new ErrorData("Bad param"))
-                                  .build());
-                res.send();
+                res.error(JsonRpcError.INVALID_PARAMS, "Bad param");
             }
+            res.send();
         }
+    }
 
-        public record StartStopParams(String when, Duration duration) {
-        }
+    record StartStopParams(String when, Duration duration) {
+    }
 
-        public record StartStopResult(String status) {
-        }
-
-        public record ErrorData(String reason) {
-        }
+    record StartStopResult(String status) {
     }
 }

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -17,9 +17,9 @@ package io.helidon.examples.webserver.jsonrpc;
 
 import java.time.Duration;
 
+import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
-import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webserver.jsonrpc.JsonRpcHandlers;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
@@ -44,7 +44,7 @@ public class JsonRpcMain {
         WebServer.builder()
                 .port(8080)
                 .host("127.0.0.1")
-                .routing(jsonRpcRouting)
+                .routing(r -> r.register("/rpc", jsonRpcRouting))
                 .build()
                 .start();
     }
@@ -81,9 +81,9 @@ public class JsonRpcMain {
         }
     }
 
-    record StartStopParams(String when, Duration duration) {
+    public record StartStopParams(String when, Duration duration) {
     }
 
-    record StartStopResult(String status) {
+    public record StartStopResult(String status) {
     }
 }

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/package-info.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JSON-RPC example.
+ */
+package io.helidon.examples.webserver.jsonrpc;

--- a/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
+++ b/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
@@ -21,17 +21,17 @@ import io.helidon.http.Status;
 import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webclient.jsonrpc.JsonRpcClientBatchRequest;
-import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import jakarta.json.Json;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.examples.webserver.jsonrpc.JsonRpcMain.StartStopResult;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static io.helidon.examples.webserver.jsonrpc.JsonRpcMain.StartStopResult;
 
 @ServerTest
 class JsonRpcTest {
@@ -42,12 +42,12 @@ class JsonRpcTest {
         this.client = client;
     }
 
-    @SetUpServer
-    static void setUpServer(WebServerConfig.Builder builder) {
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
         JsonRpcRouting jsonRpcRouting = JsonRpcRouting.builder()
                 .service(new JsonRpcMain.MachineService())
                 .build();
-        builder.routing(jsonRpcRouting);
+        builder.register("/rpc", jsonRpcRouting);
     }
 
     @Test
@@ -56,7 +56,7 @@ class JsonRpcTest {
                 .rpcId(1)
                 .param("when","NOW")
                 .param("duration", "PT0S")
-                .path("/machine")
+                .path("/rpc/machine")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
             assertThat(res.rpcId(), is(Optional.of(Json.createValue(1))));
@@ -71,7 +71,7 @@ class JsonRpcTest {
         try (var res = client.rpcMethod("stop")
                 .rpcId(2)
                 .param("when","NOW")
-                .path("/machine")
+                .path("/rpc/machine")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
             assertThat(res.rpcId(), is(Optional.of(Json.createValue(2))));
@@ -83,7 +83,7 @@ class JsonRpcTest {
 
     @Test
     void testSimpleBatch() {
-        JsonRpcClientBatchRequest batch = client.batch("/machine");
+        JsonRpcClientBatchRequest batch = client.batch("/rpc/machine");
 
         batch.rpcMethod("start")
                 .rpcId(1)

--- a/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
+++ b/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.webserver.jsonrpc;
+
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.jsonrpc.JsonRpcRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.media.type.MediaTypes.APPLICATION_JSON;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class JsonRpcTest {
+
+    static final String JSON_RPC_START = """
+            {"jsonrpc": "2.0",
+                "method": "start",
+                "params": { "when" : "NOW", "duration" : "PT0S" },
+                "id": 1}
+            """;
+
+    static final String JSON_RPC_STOP = """
+            {"jsonrpc": "2.0",
+                "method": "stop",
+                "params": { "when" : "NOW" },
+                "id": 2}
+            """;
+
+    private final Http1Client client;
+
+    JsonRpcTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        JsonRpcRouting routing = JsonRpcRouting.builder()
+                .service(new JsonRpcMain.JsonRpcService1())
+                .build();
+        router.addRouting(routing.toHttpRouting());
+    }
+
+    @Test
+    void testStart() {
+        try (var res = client.post("/jsonrpc")
+                .contentType(APPLICATION_JSON)
+                .submit(JSON_RPC_START)) {
+            assertThat(res.status().code(), is(200));
+            JsonObject json = res.as(JsonObject.class).getJsonObject("result");
+            assertThat(json.getString("status"), is("RUNNING"));
+        }
+    }
+
+    @Test
+    void testStop() {
+        try (var res = client.post("/jsonrpc")
+                .contentType(APPLICATION_JSON)
+                .submit(JSON_RPC_STOP)) {
+            assertThat(res.status().code(), is(200));
+            JsonObject json = res.as(JsonObject.class).getJsonObject("result");
+            assertThat(json.getString("status"), is("STOPPED"));
+        }
+    }
+
+    @Test
+    void testStartError() {
+        try (var res = client.post("/jsonrpc")
+                .contentType(APPLICATION_JSON)
+                .submit(JSON_RPC_START.replace("NOW", "LATER"))) {
+            assertThat(res.status().code(), is(200));
+            JsonObject json = res.as(JsonObject.class).getJsonObject("error");
+            assertThat(json.getInt("code"), is(-32600));
+            assertThat(json.getJsonObject("data").getString("reason"), is("Bad param"));
+        }
+    }
+
+    @Test
+    void testStopError() {
+        try (var res = client.post("/jsonrpc")
+                .contentType(APPLICATION_JSON)
+                .submit(JSON_RPC_STOP.replace("NOW", "LATER"))) {
+            assertThat(res.status().code(), is(200));
+            JsonObject json = res.as(JsonObject.class).getJsonObject("error");
+            assertThat(json.getInt("code"), is(-32600));
+            assertThat(json.getJsonObject("data").getString("reason"), is("Bad param"));
+        }
+    }
+}

--- a/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
+++ b/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
@@ -15,95 +15,95 @@
  */
 package io.helidon.examples.webserver.jsonrpc;
 
+import java.util.Optional;
+
 import io.helidon.http.Status;
-import io.helidon.webclient.http1.Http1Client;
-import io.helidon.webserver.Router;
-import io.helidon.webserver.jsonrpc.JsonRpcError;
+import io.helidon.jsonrpc.core.JsonRpcResult;
+import io.helidon.webclient.jsonrpc.JsonRpcClient;
+import io.helidon.webclient.jsonrpc.JsonRpcClientBatchRequest;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
-import jakarta.json.JsonObject;
+import jakarta.json.Json;
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.common.media.type.MediaTypes.APPLICATION_JSON;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static io.helidon.examples.webserver.jsonrpc.JsonRpcMain.StartStopResult;
 
 @ServerTest
 class JsonRpcTest {
 
-    static final String JSON_RPC_START = """
-            {"jsonrpc": "2.0",
-                "method": "start",
-                "params": { "when" : "NOW", "duration" : "PT0S" },
-                "id": 1}
-            """;
+    private final JsonRpcClient client;
 
-    static final String JSON_RPC_STOP = """
-            {"jsonrpc": "2.0",
-                "method": "stop",
-                "params": { "when" : "NOW" },
-                "id": 2}
-            """;
-
-    private final Http1Client client;
-
-    JsonRpcTest(Http1Client client) {
+    JsonRpcTest(JsonRpcClient client) {
         this.client = client;
     }
 
-    @SetUpRoute
-    static void routing(Router.RouterBuilder<?> router) {
-        JsonRpcRouting routing = JsonRpcRouting.builder()
-                .service(new JsonRpcMain.JsonRpcService1())
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder builder) {
+        JsonRpcRouting jsonRpcRouting = JsonRpcRouting.builder()
+                .service(new JsonRpcMain.MachineService())
                 .build();
-        router.addRouting(routing.toHttpRouting());
+        builder.routing(jsonRpcRouting);
     }
 
     @Test
     void testStart() {
-        try (var res = client.post("/jsonrpc")
-                .contentType(APPLICATION_JSON)
-                .submit(JSON_RPC_START)) {
-            assertThat(res.status().code(), is(Status.OK_200_CODE));
-            JsonObject json = res.as(JsonObject.class).getJsonObject("result");
-            assertThat(json.getString("status"), is("RUNNING"));
+        try (var res = client.rpcMethod("start")
+                .rpcId(1)
+                .param("when","NOW")
+                .param("duration", "PT0S")
+                .path("/machine")
+                .submit()) {
+            assertThat(res.status(), is(Status.OK_200));
+            assertThat(res.rpcId(), is(Optional.of(Json.createValue(1))));
+            assertThat(res.result().isPresent(), is(true));
+            StartStopResult result = res.result().get().as(StartStopResult.class);
+            assertThat(result.status(), is("RUNNING"));
         }
     }
 
     @Test
     void testStop() {
-        try (var res = client.post("/jsonrpc")
-                .contentType(APPLICATION_JSON)
-                .submit(JSON_RPC_STOP)) {
-            assertThat(res.status().code(), is(Status.OK_200_CODE));
-            JsonObject json = res.as(JsonObject.class).getJsonObject("result");
-            assertThat(json.getString("status"), is("STOPPED"));
+        try (var res = client.rpcMethod("stop")
+                .rpcId(2)
+                .param("when","NOW")
+                .path("/machine")
+                .submit()) {
+            assertThat(res.status(), is(Status.OK_200));
+            assertThat(res.rpcId(), is(Optional.of(Json.createValue(2))));
+            assertThat(res.result().isPresent(), is(true));
+            StartStopResult result = res.result().get().as(StartStopResult.class);
+            assertThat(result.status(), is("STOPPED"));
         }
     }
 
     @Test
-    void testStartError() {
-        try (var res = client.post("/jsonrpc")
-                .contentType(APPLICATION_JSON)
-                .submit(JSON_RPC_START.replace("NOW", "LATER"))) {
-            assertThat(res.status().code(), is(Status.OK_200_CODE));
-            JsonObject json = res.as(JsonObject.class).getJsonObject("error");
-            assertThat(json.getInt("code"), is(JsonRpcError.INVALID_PARAMS));
-            assertThat(json.getJsonObject("data").getString("reason"), is("Bad param"));
-        }
-    }
+    void testSimpleBatch() {
+        JsonRpcClientBatchRequest batch = client.batch("/machine");
 
-    @Test
-    void testStopError() {
-        try (var res = client.post("/jsonrpc")
-                .contentType(APPLICATION_JSON)
-                .submit(JSON_RPC_STOP.replace("NOW", "LATER"))) {
-            assertThat(res.status().code(), is(Status.OK_200_CODE));
-            JsonObject json = res.as(JsonObject.class).getJsonObject("error");
-            assertThat(json.getInt("code"), is(JsonRpcError.INVALID_PARAMS));
-            assertThat(json.getJsonObject("data").getString("reason"), is("Bad param"));
+        batch.rpcMethod("start")
+                .rpcId(1)
+                .param("when", "NOW")
+                .param("duration", "PT0S")
+                .addToBatch()
+                .rpcMethod("stop")
+                .rpcId(2)
+                .param("when","NOW")
+                .addToBatch();
+
+        try (var res = batch.submit()) {
+            assertThat(res.status(), is(Status.OK_200));
+            assertThat(res.size(), is(2));
+            Optional<JsonRpcResult> result0 = res.get(0).result();
+            assertThat(result0.isPresent(), is(true));
+            assertThat(result0.get().as(StartStopResult.class).status(), is("RUNNING"));
+            Optional<JsonRpcResult> result1 = res.get(1).result();
+            assertThat(result1.isPresent(), is(true));
+            assertThat(result1.get().as(StartStopResult.class).status(), is("STOPPED"));
         }
     }
 }

--- a/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
+++ b/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
@@ -15,8 +15,10 @@
  */
 package io.helidon.examples.webserver.jsonrpc;
 
+import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.Router;
+import io.helidon.webserver.jsonrpc.JsonRpcError;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
@@ -64,7 +66,7 @@ class JsonRpcTest {
         try (var res = client.post("/jsonrpc")
                 .contentType(APPLICATION_JSON)
                 .submit(JSON_RPC_START)) {
-            assertThat(res.status().code(), is(200));
+            assertThat(res.status().code(), is(Status.OK_200_CODE));
             JsonObject json = res.as(JsonObject.class).getJsonObject("result");
             assertThat(json.getString("status"), is("RUNNING"));
         }
@@ -75,7 +77,7 @@ class JsonRpcTest {
         try (var res = client.post("/jsonrpc")
                 .contentType(APPLICATION_JSON)
                 .submit(JSON_RPC_STOP)) {
-            assertThat(res.status().code(), is(200));
+            assertThat(res.status().code(), is(Status.OK_200_CODE));
             JsonObject json = res.as(JsonObject.class).getJsonObject("result");
             assertThat(json.getString("status"), is("STOPPED"));
         }
@@ -86,9 +88,9 @@ class JsonRpcTest {
         try (var res = client.post("/jsonrpc")
                 .contentType(APPLICATION_JSON)
                 .submit(JSON_RPC_START.replace("NOW", "LATER"))) {
-            assertThat(res.status().code(), is(200));
+            assertThat(res.status().code(), is(Status.OK_200_CODE));
             JsonObject json = res.as(JsonObject.class).getJsonObject("error");
-            assertThat(json.getInt("code"), is(-32600));
+            assertThat(json.getInt("code"), is(JsonRpcError.INVALID_PARAMS));
             assertThat(json.getJsonObject("data").getString("reason"), is("Bad param"));
         }
     }
@@ -98,9 +100,9 @@ class JsonRpcTest {
         try (var res = client.post("/jsonrpc")
                 .contentType(APPLICATION_JSON)
                 .submit(JSON_RPC_STOP.replace("NOW", "LATER"))) {
-            assertThat(res.status().code(), is(200));
+            assertThat(res.status().code(), is(Status.OK_200_CODE));
             JsonObject json = res.as(JsonObject.class).getJsonObject("error");
-            assertThat(json.getInt("code"), is(-32600));
+            assertThat(json.getInt("code"), is(JsonRpcError.INVALID_PARAMS));
             assertThat(json.getJsonObject("data").getString("reason"), is("Bad param"));
         }
     }

--- a/examples/webserver/pom.xml
+++ b/examples/webserver/pom.xml
@@ -42,6 +42,7 @@
         <module>grpc</module>
         <module>grpc-random</module>
         <module>imperative</module>
+        <module>jsonrpc</module>
         <module>multiport</module>
         <module>mutual-tls</module>
         <module>observe</module>


### PR DESCRIPTION
New example that shows how to use the new JSON-RPC API. Test uses client JSON-RPC API as well.

Depends on https://github.com/helidon-io/helidon/pull/10244