### PR TITLE
4.x: Remove use of io.helidon.common.config.Config

### DIFF
--- a/examples/integrations/langchain4j/coffee-shop-assistant-se/src/main/java/io/helidon/examples/integrations/langchain4j/se/coffee/shop/assistant/ApplicationMain.java
+++ b/examples/integrations/langchain4j/coffee-shop-assistant-se/src/main/java/io/helidon/examples/integrations/langchain4j/se/coffee/shop/assistant/ApplicationMain.java
@@ -15,7 +15,7 @@
  */
 package io.helidon.examples.integrations.langchain4j.se.coffee.shop.assistant;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.examples.integrations.langchain4j.se.coffee.shop.assistant.ai.MenuItemsIngestor;
 import io.helidon.examples.integrations.langchain4j.se.coffee.shop.assistant.rest.ChatBotService;
 import io.helidon.logging.common.LogConfig;

--- a/examples/integrations/langchain4j/coffee-shop-assistant-se/src/main/java/io/helidon/examples/integrations/langchain4j/se/coffee/shop/assistant/ai/MenuItemsIngestor.java
+++ b/examples/integrations/langchain4j/coffee-shop-assistant-se/src/main/java/io/helidon/examples/integrations/langchain4j/se/coffee/shop/assistant/ai/MenuItemsIngestor.java
@@ -17,7 +17,7 @@ package io.helidon.examples.integrations.langchain4j.se.coffee.shop.assistant.ai
 
 import java.util.logging.Logger;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.examples.integrations.langchain4j.se.coffee.shop.assistant.data.MenuItem;
 import io.helidon.examples.integrations.langchain4j.se.coffee.shop.assistant.data.MenuItemsService;
 import io.helidon.service.registry.Service;

--- a/examples/integrations/langchain4j/coffee-shop-assistant-se/src/main/java/io/helidon/examples/integrations/langchain4j/se/coffee/shop/assistant/data/MenuItemsService.java
+++ b/examples/integrations/langchain4j/coffee-shop-assistant-se/src/main/java/io/helidon/examples/integrations/langchain4j/se/coffee/shop/assistant/data/MenuItemsService.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.service.registry.Service;
 
 import com.fasterxml.jackson.core.type.TypeReference;


### PR DESCRIPTION
Removes use of `io.helidon.common.config.Config` from langchain4j example. After this PR the remaining example that use common config is:

* `security/spi-examples`