### PR TITLE
4.2.x: Remove uses of Config.global(config) setter

### DIFF
--- a/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         // Get webserver config from the "server" section of application.yaml
         WebServerConfig.Builder builder = WebServer.builder();

--- a/examples/integrations/micrometer/se/src/main/java/io/helidon/examples/integrations/micrometer/se/Main.java
+++ b/examples/integrations/micrometer/se/src/main/java/io/helidon/examples/integrations/micrometer/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        // and initialize global config
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer server = WebServer.builder()
                 .config(config.get("server"))

--- a/examples/integrations/oci/genai/src/main/java/io/helidon/examples/integrations/oci/genai/OciGenAiMain.java
+++ b/examples/integrations/oci/genai/src/main/java/io/helidon/examples/integrations/oci/genai/OciGenAiMain.java
@@ -44,8 +44,7 @@ public final class OciGenAiMain {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         // Prepare routing for the server
         WebServer server = WebServer.builder()

--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/Main.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,8 +55,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         server.routing(Main::routing)
                 .config(config.get("server"));

--- a/examples/metrics/exemplar/src/test/java/io/helidon/examples/metrics/exemplar/MainTest.java
+++ b/examples/metrics/exemplar/src/test/java/io/helidon/examples/metrics/exemplar/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class MainTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
-        Config.global(Config.create());
+        Config.global();
         server.routing(Main::routing);
     }
 

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,8 +66,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         // Programmatically (not through config), tell the metrics feature to ignore the "gets" timer.
         // To do so, create the scope config, then add it to the metrics config that ultimately

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/Main.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         server.routing(Main::routing)
                 .config(config.get("server"));

--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class StatusTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
-        Config.global(Config.create());
+        Config.global();
         server.routing(r -> {
             Main.routing(r);
             r.register("/status", new StatusService());

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         /*
          * For purposes of illustration, the key performance indicator settings for the

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,8 +56,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         server.config(config.get("server"))
                 .routing(Main::routing);

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer server = WebServer.builder()
                 .config(config.get("server"))

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer server = WebServer.builder()
                 .config(config.get("server"))

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,7 @@ public final class ServerMain {
      */
     public static void main(String[] args) {
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServerConfig.Builder builder = WebServer.builder();
         setup(builder);

--- a/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
+++ b/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,6 @@ public class ClientMainTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
-        Config.global(Config.create());
         ServerMain.setup(server);
     }
 

--- a/examples/webserver/concurrency-limits/src/main/java/io/helidon/examples/webserver/concurrencylimits/Main.java
+++ b/examples/webserver/concurrency-limits/src/main/java/io/helidon/examples/webserver/concurrencylimits/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ public class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         // Default port uses the fixed limiter
         // "aimd" port uses the AIMD limiter

--- a/examples/webserver/grpc-random/src/main/java/io/helidon/examples/webserver/grpc/random/Main.java
+++ b/examples/webserver/grpc-random/src/main/java/io/helidon/examples/webserver/grpc/random/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,7 @@ class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
         Config serverConfig = config.get("server");
 
         // start server and register gRPC routing

--- a/examples/webserver/grpc/src/main/java/io/helidon/examples/webserver/grpc/GrpcMain.java
+++ b/examples/webserver/grpc/src/main/java/io/helidon/examples/webserver/grpc/GrpcMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,7 @@ class GrpcMain {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
         Config serverConfig = config.get("server");
 
         // create a health check to verify gRPC endpoint

--- a/examples/webserver/imperative/src/main/java/io/helidon/examples/webserver/imperative/ImperativeMain.java
+++ b/examples/webserver/imperative/src/main/java/io/helidon/examples/webserver/imperative/ImperativeMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ public final class ImperativeMain {
      * @param args ignored
      */
     public static void main(String[] args) {
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer server = WebServer.create(ws -> ws.config(config.get("server"))
                         .routing(ImperativeMain::routing))

--- a/examples/webserver/multiport/src/main/java/io/helidon/webserver/examples/multiport/Main.java
+++ b/examples/webserver/multiport/src/main/java/io/helidon/webserver/examples/multiport/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer server = WebServer.builder()
                 .config(config.get("server"))

--- a/examples/webserver/protocols-custom/src/main/java/io/helidon/examples/webserver/sdp/Main.java
+++ b/examples/webserver/protocols-custom/src/main/java/io/helidon/examples/webserver/sdp/Main.java
@@ -41,8 +41,7 @@ public class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer server = WebServer.builder()
                 .config(config.get("server"))

--- a/examples/webserver/ratelimit/src/main/java/io/helidon/examples/webserver/ratelimit/Main.java
+++ b/examples/webserver/ratelimit/src/main/java/io/helidon/examples/webserver/ratelimit/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ public class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServerConfig webserverConfig = WebServer.builder()
                 .config(config.get("server"))

--- a/examples/webserver/threads/src/main/java/io/helidon/examples/webserver/threads/Main.java
+++ b/examples/webserver/threads/src/main/java/io/helidon/examples/webserver/threads/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ public class Main {
         LogConfig.configureRuntime();
 
         // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        Config config = Config.global();
 
         WebServer webserver = WebServer.builder()
                 .config(config.get("server"))


### PR DESCRIPTION
4.2.x: Remove uses of `Config.global(config)` setter from examples. After this PR the remaining examples that use the setter are:

* `examples/dbclient/jdbc` 
* `examples/dbclient/pokemons`

This retains the use of `Config.global()` getter because `Services.get(io.helidon.config.Config)` does not currently work with Helidon 4.2.x due to https://github.com/helidon-io/helidon/issues/10360


