### PR TITLE
4.x:  Update build lifecycle to install and don't ignore failed tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -197,4 +197,4 @@ jobs:
       - name: Maven build
         run: etc/scripts/build.sh
         env:
-          MAVEN_ARGS: -pl !examples/integrations/micronaut/data
+          MAVEN_ARGS: -pl !examples/integrations/micronaut/data,!examples/integrations/microstream/greetings-se,!examples/integrations/microstream/greetings-mp

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -47,5 +47,4 @@ mvn ${MAVEN_ARGS} --version
 # shellcheck disable=SC2086
 mvn -B ${MAVEN_ARGS} \
     -f "${WS_DIR}"/pom.xml \
-    -Dmaven.test.failure.ignore=true \
-    clean package
+    clean install


### PR DESCRIPTION

Updates the build validation to:

* Use install lifecycle to ensure integration tests are run
* Don't ignore test failures
* For latest JDK test: skip examples with dependencies that don't support Java 25

