### PR TITLE
4.x Fix typo in packaging example readme

### DIFF
--- a/examples/packaging/README.md
+++ b/examples/packaging/README.md
@@ -173,8 +173,11 @@ To generate the fat jar:
 
 ```shell
 mvn package -Pfat-jar
-```shell
+```
+
 This will create `target/helidon-examples-packaging-fat.jar` which can be run with:
+
 ```shell
 java -jar target/helidon-examples-packaging-fat.jar
 ```
+


### PR DESCRIPTION
 Fix typo in packaging example readme

