### PR TITLE
Update packaging example to leverage 4.3.0 mergeable meta-data

### DIFF
--- a/examples/packaging/README.md
+++ b/examples/packaging/README.md
@@ -160,14 +160,10 @@ That said, it is possible to create a fat Jar for your Helidon application.
 
 #### Fat Jar Distribution
 
-This example uses the `maven-assembly-plugin` with the `helidon-assembly-extension` to create a fat jar. 
-Specifically see:
+This example uses the `maven-assembly-plugin` to create a fat jar. Specifically see:
 
 1. The `fat-jar` profile in the [pom.xml](./pom.xml) to configure the plugin.
 2. The assembly descriptor in [fat-assembly.xml](./src/main/assembly/fat-assembly.xml). 
-
-Note that the plugin and descriptor use the `helidon-assembly-extension` which handles merging
-of Helidon json metadata that resides in Helidon jar files.
 
 To generate the fat jar:
 

--- a/examples/packaging/pom.xml
+++ b/examples/packaging/pom.xml
@@ -30,7 +30,6 @@
 
     <properties>
         <mainClass>io.helidon.examples.packaging.Main</mainClass>
-        <helidon.build-tools.version>4.0.20</helidon.build-tools.version>
     </properties>
 
     <dependencies>
@@ -109,13 +108,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>io.helidon.build-tools</groupId>
-                                <artifactId>helidon-assembly-extension</artifactId>
-                                <version>${helidon.build-tools.version}</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/examples/packaging/src/main/assembly/fat-assembly.xml
+++ b/examples/packaging/src/main/assembly/fat-assembly.xml
@@ -33,10 +33,16 @@
 
     <containerDescriptorHandlers>
         <containerDescriptorHandler>
-            <handlerName>helidon</handlerName>
+            <handlerName>metaInf-services</handlerName>
         </containerDescriptorHandler>
         <containerDescriptorHandler>
-            <handlerName>metaInf-services</handlerName>
+            <!-- Merge Helidon's meta-data manifest file. -->
+            <!-- Not strictly required, but more correct and efficient -->
+            <handlerName>file-aggregator</handlerName>
+            <configuration>
+                <filePattern>META-INF/helidon/manifest</filePattern>
+                <outputPath>META-INF/helidon/manifest</outputPath>
+            </configuration>
         </containerDescriptorHandler>
     </containerDescriptorHandlers>
 


### PR DESCRIPTION
Updates the packaging example for 4.3.0 to not use the helidon-assembly-extension for packaging fat jars because in 4.3.0 Helidon meta-data is inherently mergeable.

Fixes #205