### PR TITLE
4.x: Update Helidon version to 4.4.0-SNAPSHOT

### DIFF
--- a/examples/coherence/pom.xml
+++ b/examples/coherence/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/config/basics/pom.xml
+++ b/examples/config/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/changes/pom.xml
+++ b/examples/config/changes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/encryption/pom.xml
+++ b/examples/config/encryption/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/git/pom.xml
+++ b/examples/config/git/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/mapping/pom.xml
+++ b/examples/config/mapping/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/metadata/pom.xml
+++ b/examples/config/metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/overrides/pom.xml
+++ b/examples/config/overrides/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/profiles/pom.xml
+++ b/examples/config/profiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/sources/pom.xml
+++ b/examples/config/sources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/cors/pom.xml
+++ b/examples/cors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/data/pom.xml
+++ b/examples/data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.data</groupId>

--- a/examples/dbclient/h2/pom.xml
+++ b/examples/dbclient/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/health/pom.xml
+++ b/examples/dbclient/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/metrics/pom.xml
+++ b/examples/dbclient/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/mongodb/pom.xml
+++ b/examples/dbclient/mongodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/mysql/pom.xml
+++ b/examples/dbclient/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/oracle-ucp/pom.xml
+++ b/examples/dbclient/oracle-ucp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/oracle/pom.xml
+++ b/examples/dbclient/oracle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/postgres/pom.xml
+++ b/examples/dbclient/postgres/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/dbclient/tracing/pom.xml
+++ b/examples/dbclient/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.dbclient</groupId>

--- a/examples/declarative/data/pom.xml
+++ b/examples/declarative/data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/declarative/server/pom.xml
+++ b/examples/declarative/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/graphql/basics/pom.xml
+++ b/examples/graphql/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.graphql</groupId>

--- a/examples/health/basics/pom.xml
+++ b/examples/health/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.health</groupId>

--- a/examples/inject/pom.xml
+++ b/examples/inject/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/integrations/cdi/datasource/hikaricp-h2/pom.xml
+++ b/examples/integrations/cdi/datasource/hikaricp-h2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.datasource</groupId>

--- a/examples/integrations/cdi/datasource/hikaricp-mysql/pom.xml
+++ b/examples/integrations/cdi/datasource/hikaricp-mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.datasource</groupId>

--- a/examples/integrations/cdi/datasource/hikaricp-oracle/pom.xml
+++ b/examples/integrations/cdi/datasource/hikaricp-oracle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.datasource</groupId>

--- a/examples/integrations/cdi/datasource/hikaricp-postgres/pom.xml
+++ b/examples/integrations/cdi/datasource/hikaricp-postgres/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.datasource</groupId>

--- a/examples/integrations/cdi/jpa/h2/pom.xml
+++ b/examples/integrations/cdi/jpa/h2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.jpa</groupId>

--- a/examples/integrations/cdi/jpa/mysql/pom.xml
+++ b/examples/integrations/cdi/jpa/mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.jpa</groupId>

--- a/examples/integrations/cdi/jpa/oracle/pom.xml
+++ b/examples/integrations/cdi/jpa/oracle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.jpa</groupId>

--- a/examples/integrations/cdi/jpa/postgres/pom.xml
+++ b/examples/integrations/cdi/jpa/postgres/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi.jpa</groupId>

--- a/examples/integrations/langchain4j/coffee-shop-assistant-mp/pom.xml
+++ b/examples/integrations/langchain4j/coffee-shop-assistant-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/langchain4j/coffee-shop-assistant-se-coherence/pom.xml
+++ b/examples/integrations/langchain4j/coffee-shop-assistant-se-coherence/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/langchain4j/coffee-shop-assistant-se/pom.xml
+++ b/examples/integrations/langchain4j/coffee-shop-assistant-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/micrometer/mp/pom.xml
+++ b/examples/integrations/micrometer/mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/integrations/micrometer/se/pom.xml
+++ b/examples/integrations/micrometer/se/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/micronaut/data/pom.xml
+++ b/examples/integrations/micronaut/data/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>helidon-examples-integrations-micronaut-data</artifactId>

--- a/examples/integrations/microstream/greetings-mp/pom.xml
+++ b/examples/integrations/microstream/greetings-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/microstream/greetings-se/pom.xml
+++ b/examples/integrations/microstream/greetings-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/neo4j/pom.xml
+++ b/examples/integrations/neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>helidon-examples-integration-neo4j</artifactId>

--- a/examples/integrations/oci/atp-cdi/pom.xml
+++ b/examples/integrations/oci/atp-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/atp/pom.xml
+++ b/examples/integrations/oci/atp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/genai-cdi/pom.xml
+++ b/examples/integrations/oci/genai-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/genai/pom.xml
+++ b/examples/integrations/oci/genai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/metrics/pom.xml
+++ b/examples/integrations/oci/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/objectstorage-cdi/pom.xml
+++ b/examples/integrations/oci/objectstorage-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/objectstorage/pom.xml
+++ b/examples/integrations/oci/objectstorage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/vault-cdi/pom.xml
+++ b/examples/integrations/oci/vault-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/oci/vault/pom.xml
+++ b/examples/integrations/oci/vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/vault/hcp-cdi/pom.xml
+++ b/examples/integrations/vault/hcp-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/integrations/vault/hcp/pom.xml
+++ b/examples/integrations/vault/hcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/jbatch/pom.xml
+++ b/examples/jbatch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.jbatch</groupId>

--- a/examples/logging/jul/pom.xml
+++ b/examples/logging/jul/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/log4j/pom.xml
+++ b/examples/logging/log4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/logback-aot/pom.xml
+++ b/examples/logging/logback-aot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/slf4j/pom.xml
+++ b/examples/logging/slf4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/media/form/pom.xml
+++ b/examples/media/form/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.media</groupId>

--- a/examples/media/json-patch/pom.xml
+++ b/examples/media/json-patch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.media</groupId>

--- a/examples/media/multipart/pom.xml
+++ b/examples/media/multipart/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.media</groupId>

--- a/examples/messaging/jms-websocket-mp/pom.xml
+++ b/examples/messaging/jms-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.jms</groupId>

--- a/examples/messaging/jms-websocket-se/pom.xml
+++ b/examples/messaging/jms-websocket-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.jms</groupId>

--- a/examples/messaging/kafka-websocket-mp/pom.xml
+++ b/examples/messaging/kafka-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.mp</groupId>

--- a/examples/messaging/kafka-websocket-se/pom.xml
+++ b/examples/messaging/kafka-websocket-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.se</groupId>

--- a/examples/messaging/oracle-aq-websocket-mp/pom.xml
+++ b/examples/messaging/oracle-aq-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.aq</groupId>

--- a/examples/messaging/weblogic-jms-mp/pom.xml
+++ b/examples/messaging/weblogic-jms-mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.messaging.wls</groupId>

--- a/examples/metrics/exemplar/pom.xml
+++ b/examples/metrics/exemplar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/filtering/mp/pom.xml
+++ b/examples/metrics/filtering/mp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/filtering/se/pom.xml
+++ b/examples/metrics/filtering/se/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/http-status-count-se/pom.xml
+++ b/examples/metrics/http-status-count-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/metrics/kpi/pom.xml
+++ b/examples/metrics/kpi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/microprofile/bean-validation/pom.xml
+++ b/examples/microprofile/bean-validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/coherence/pom.xml
+++ b/examples/microprofile/coherence/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/cors/pom.xml
+++ b/examples/microprofile/cors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/data/pom.xml
+++ b/examples/microprofile/data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/microprofile/graphql/pom.xml
+++ b/examples/microprofile/graphql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/grpc/pom.xml
+++ b/examples/microprofile/grpc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <artifactId>helidon-examples-microprofile-hello-world-explicit</artifactId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/http-status-count-mp/pom.xml
+++ b/examples/microprofile/http-status-count-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/microprofile/idcs/pom.xml
+++ b/examples/microprofile/idcs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/json-patch/pom.xml
+++ b/examples/microprofile/json-patch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/lra/pom.xml
+++ b/examples/microprofile/lra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/messaging-sse/pom.xml
+++ b/examples/microprofile/messaging-sse/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/multipart/pom.xml
+++ b/examples/microprofile/multipart/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/multiport/pom.xml
+++ b/examples/microprofile/multiport/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/oci-tls-certificates/pom.xml
+++ b/examples/microprofile/oci-tls-certificates/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/microprofile/oidc/pom.xml
+++ b/examples/microprofile/oidc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/openapi/basic/pom.xml
+++ b/examples/microprofile/openapi/basic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/openapi/expanded-jandex/pom.xml
+++ b/examples/microprofile/openapi/expanded-jandex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/security/pom.xml
+++ b/examples/microprofile/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/static-content/pom.xml
+++ b/examples/microprofile/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/telemetry/greeting/pom.xml
+++ b/examples/microprofile/telemetry/greeting/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/telemetry/secondary/pom.xml
+++ b/examples/microprofile/telemetry/secondary/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/threads/pom.xml
+++ b/examples/microprofile/threads/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/tls/pom.xml
+++ b/examples/microprofile/tls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/microprofile/websocket/pom.xml
+++ b/examples/microprofile/websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/packaging/pom.xml
+++ b/examples/packaging/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.packaging</groupId>

--- a/examples/quickstarts/helidon-quickstart-inject/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-inject/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.quickstarts</groupId>

--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 }
 
 ext {
-    helidonversion = '4.3.0-SNAPSHOT'
+    helidonversion = '4.4.0-SNAPSHOT'
     mainClass='io.helidon.microprofile.cdi.Main'
 }
 

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.quickstarts</groupId>

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -34,7 +34,7 @@ tasks.withType(JavaCompile) {
 }
 
 ext {
-    helidonversion = '4.3.0-SNAPSHOT'
+    helidonversion = '4.4.0-SNAPSHOT'
     mainClass='io.helidon.examples.quickstart.se.Main'
 }
 

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.quickstarts</groupId>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -26,7 +26,7 @@
     <name>Helidon Examples Standalone Quickstart MP</name>
 
     <properties>
-        <helidon.version>4.3.0-SNAPSHOT</helidon.version>
+        <helidon.version>4.4.0-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.Main</mainClass>
 
         <maven.compiler.source>21</maven.compiler.source>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -27,7 +27,7 @@
     <name>Helidon Examples Standalone Quickstart SE</name>
 
     <properties>
-        <helidon.version>4.3.0-SNAPSHOT</helidon.version>
+        <helidon.version>4.4.0-SNAPSHOT</helidon.version>
         <helidon.test.config.profile>test</helidon.test.config.profile>
         <mainClass>io.helidon.examples.quickstart.se.Main</mainClass>
 

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/basic-auth-with-static-content/pom.xml
+++ b/examples/security/basic-auth-with-static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/google-login/pom.xml
+++ b/examples/security/google-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/outbound-override/pom.xml
+++ b/examples/security/outbound-override/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/programmatic/pom.xml
+++ b/examples/security/programmatic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/spi-examples/pom.xml
+++ b/examples/security/spi-examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/vaults/pom.xml
+++ b/examples/security/vaults/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-digest-auth/pom.xml
+++ b/examples/security/webserver-digest-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-signatures/pom.xml
+++ b/examples/security/webserver-signatures/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/telemetry/config/pom.xml
+++ b/examples/telemetry/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.telemetry</groupId>

--- a/examples/todo-app/backend/pom.xml
+++ b/examples/todo-app/backend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.todos</groupId>

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.todo</groupId>

--- a/examples/translator-app/backend/pom.xml
+++ b/examples/translator-app/backend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>

--- a/examples/translator-app/frontend/pom.xml
+++ b/examples/translator-app/frontend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>

--- a/examples/webclient/standalone/pom.xml
+++ b/examples/webclient/standalone/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/basic/pom.xml
+++ b/examples/webserver/basic/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/basics/pom.xml
+++ b/examples/webserver/basics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/comment-aas/pom.xml
+++ b/examples/webserver/comment-aas/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/concurrency-limits/pom.xml
+++ b/examples/webserver/concurrency-limits/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/echo/pom.xml
+++ b/examples/webserver/echo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/fault-tolerance/pom.xml
+++ b/examples/webserver/fault-tolerance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/grpc-random/pom.xml
+++ b/examples/webserver/grpc-random/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/grpc/pom.xml
+++ b/examples/webserver/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/imperative/pom.xml
+++ b/examples/webserver/imperative/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/multiport/pom.xml
+++ b/examples/webserver/multiport/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/mutual-tls/pom.xml
+++ b/examples/webserver/mutual-tls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/observe/pom.xml
+++ b/examples/webserver/observe/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/opentracing/pom.xml
+++ b/examples/webserver/opentracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/protocols-custom/pom.xml
+++ b/examples/webserver/protocols-custom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/protocols/pom.xml
+++ b/examples/webserver/protocols/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/ratelimit/pom.xml
+++ b/examples/webserver/ratelimit/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/sse/pom.xml
+++ b/examples/webserver/sse/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/static-content/pom.xml
+++ b/examples/webserver/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/streaming/pom.xml
+++ b/examples/webserver/streaming/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/threads/pom.xml
+++ b/examples/webserver/threads/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/tls/pom.xml
+++ b/examples/webserver/tls/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/tracing/pom.xml
+++ b/examples/webserver/tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/examples/webserver/tutorial/pom.xml
+++ b/examples/webserver/tutorial/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/websocket/pom.xml
+++ b/examples/webserver/websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-dependencies</artifactId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.examples</groupId>
@@ -61,7 +61,7 @@
         <version.java>21</version.java>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <helidon.version>4.3.0-SNAPSHOT</helidon.version>
+        <helidon.version>4.4.0-SNAPSHOT</helidon.version>
 
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Medium</spotbugs.threshold>


### PR DESCRIPTION
Update Helidon version in examples to 4.4.0-SNAPSHOT. The validation build will fail until https://github.com/helidon-io/helidon/pull/10830 is merged into the helidon repository.