### PR TITLE
4.x convert telemetry example to use OTLP exporter

### DIFF
--- a/etc/scripts/prime-build.sh
+++ b/etc/scripts/prime-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,5 +83,5 @@ echo "Building Helidon version ${HELIDON_VERSION} from Helidon repo branch ${HEL
 mvn ${MAVEN_ARGS} -T8 \
   -f helidon/pom.xml \
   -DskipTests \
-  -Dmaven.test.skip=true \
+  -Dmaven.test.skip=false \
   install

--- a/examples/microprofile/telemetry/README.md
+++ b/examples/microprofile/telemetry/README.md
@@ -11,26 +11,19 @@ java -jar greeting/target/helidon-examples-microprofile-telemetry-greeting.jar
 
 Run Jaeger tracer. If you prefer to use Docker, run in terminal:
 ```shell
-docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-  -e COLLECTOR_OTLP_ENABLED=true \
-  -p 6831:6831/udp \
-  -p 6832:6832/udp \
-  -p 5778:5778 \
+docker run -d --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
   -p 4318:4318 \
-  -p 14250:14250 \
-  -p 14268:14268 \
-  -p 14269:14269 \
+  -p 5778:5778 \
   -p 9411:9411 \
-  jaegertracing/all-in-one:1.50
+  cr.jaegertracing.io/jaegertracing/jaeger:2.14.0
 ```
 
 If you have Jaeger all-in-one installed, use this command:
 
 ```shell
-jaeger-all-in-one --collector.zipkin.host-port=9411   --collector.otlp.enabled=true
+jaeger
 ```
 
 Run the Secondary service:

--- a/examples/microprofile/telemetry/greeting/pom.xml
+++ b/examples/microprofile/telemetry/greeting/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.telemetry</groupId>

--- a/examples/microprofile/telemetry/greeting/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/microprofile/telemetry/greeting/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ metrics.rest-request.enabled=true
 
 #OpenTelemtry
 otel.sdk.disabled=false
-otel.traces.exporter=jaeger
+otel.traces.exporter=otlp
 otel.service.name=greeting-service
 
 #telemetry.span.full.url=true

--- a/examples/microprofile/telemetry/secondary/pom.xml
+++ b/examples/microprofile/telemetry/secondary/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/examples/microprofile/telemetry/secondary/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/microprofile/telemetry/secondary/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,6 @@ metrics.rest-request.enabled=true
 
 #OpenTelemtry
 otel.sdk.disabled=false
-otel.traces.exporter=jaeger
+otel.traces.exporter=otlp
 otel.service.name=secondary-service
 


### PR DESCRIPTION
Resolves #232 

The PR changes the two MP telemetry example apps to use the OpenTelemetry OTLP exporter instead of the obsolete Jaeger one which is no longer even present in later OTel releases.

The instructions are also updated to use a more recent Jaeger backend release.

The change to `prime-build.sh` is to work around an apparent false failure in the dependency usage check.