### PR TITLE
Allow example to work with newer OpenTelemetry release which has no Jaeger exporter

### DIFF
--- a/examples/dbclient/tracing/README.md
+++ b/examples/dbclient/tracing/README.md
@@ -10,11 +10,11 @@ mvn package
 
 ## Run
 
-Start the database:
+Start the Jaeger backend:
 ```shell
 docker run -d \
   --name jaeger \
-  -p 14250:14250 \
+  -p 4317:4317 \
   -p 16686:16686 \
   cr.jaegertracing.io/jaegertracing/jaeger:2.10.0
 ```

--- a/examples/dbclient/tracing/src/main/resources/application.yaml
+++ b/examples/dbclient/tracing/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ server:
 
 tracing:
   service: helidon-examples-dbclient-tracing
-  path: /api/traces
-  port: 14250
 
 db:
   source: jdbc

--- a/examples/dbclient/tracing/src/test/java/io/helidon/examples/dbclient/tracing/DbClientTracingTest.java
+++ b/examples/dbclient/tracing/src/test/java/io/helidon/examples/dbclient/tracing/DbClientTracingTest.java
@@ -52,12 +52,13 @@ import static org.hamcrest.Matchers.is;
 class DbClientTracingTest {
 
     private static final DockerImageName IMAGE = DockerImageName.parse("cr.jaegertracing.io/jaegertracing/jaeger:2.10.0");
+    private static final int SPAN_DATA_PORT = 4317;
 
     @Container
     @SuppressWarnings("resource")
     private static final GenericContainer<?> CONTAINER = new GenericContainer<>(IMAGE)
-            .withExposedPorts(14250, 16686)
-            .waitingFor(Wait.forListeningPorts(14250, 16686)
+            .withExposedPorts(SPAN_DATA_PORT, 16686)
+            .waitingFor(Wait.forListeningPorts(SPAN_DATA_PORT, 16686)
                                 .withStartupTimeout(Duration.ofMinutes(2)));
 
     private final Http1Client jaegerClient = Http1Client.builder()
@@ -70,7 +71,7 @@ class DbClientTracingTest {
     }
 
     static int tracingPort() {
-        return CONTAINER.getMappedPort(14250);
+        return CONTAINER.getMappedPort(SPAN_DATA_PORT);
     }
 
     @SetUpServer


### PR DESCRIPTION
Resolves #236 

## Release Note
____
The DbClient tracing example now works with the latest release of Helidon which adopts a more recent release of OpenTelemetry.
____

The test referred to Jaeger specific port numbers and config settings. The PR changes those.

