### PR TITLE
Restore db client tracing example to former state, using the updated core Helidon Jaeger tracing provider

### DIFF
--- a/examples/dbclient/tracing/README.md
+++ b/examples/dbclient/tracing/README.md
@@ -10,11 +10,11 @@ mvn package
 
 ## Run
 
-Start the Jaeger backend:
+Start the database:
 ```shell
 docker run -d \
   --name jaeger \
-  -p 4317:4317 \
+  -p 14250:14250 \
   -p 16686:16686 \
   cr.jaegertracing.io/jaegertracing/jaeger:2.10.0
 ```

--- a/examples/dbclient/tracing/src/main/resources/application.yaml
+++ b/examples/dbclient/tracing/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/dbclient/tracing/src/main/resources/application.yaml
+++ b/examples/dbclient/tracing/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+# Copyright (c) 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ server:
 
 tracing:
   service: helidon-examples-dbclient-tracing
+  path: /api/traces
+  port: 14250
 
 db:
   source: jdbc

--- a/examples/dbclient/tracing/src/test/java/io/helidon/examples/dbclient/tracing/DbClientTracingTest.java
+++ b/examples/dbclient/tracing/src/test/java/io/helidon/examples/dbclient/tracing/DbClientTracingTest.java
@@ -52,13 +52,12 @@ import static org.hamcrest.Matchers.is;
 class DbClientTracingTest {
 
     private static final DockerImageName IMAGE = DockerImageName.parse("cr.jaegertracing.io/jaegertracing/jaeger:2.10.0");
-    private static final int SPAN_DATA_PORT = 4317;
 
     @Container
     @SuppressWarnings("resource")
     private static final GenericContainer<?> CONTAINER = new GenericContainer<>(IMAGE)
-            .withExposedPorts(SPAN_DATA_PORT, 16686)
-            .waitingFor(Wait.forListeningPorts(SPAN_DATA_PORT, 16686)
+            .withExposedPorts(14250, 16686)
+            .waitingFor(Wait.forListeningPorts(14250, 16686)
                                 .withStartupTimeout(Duration.ofMinutes(2)));
 
     private final Http1Client jaegerClient = Http1Client.builder()
@@ -71,7 +70,7 @@ class DbClientTracingTest {
     }
 
     static int tracingPort() {
-        return CONTAINER.getMappedPort(SPAN_DATA_PORT);
+        return CONTAINER.getMappedPort(14250);
     }
 
     @SetUpServer


### PR DESCRIPTION
Resolves #245

Earlier PR #237 changed the DB client tracing example to use the then-updated Jaeger tracing provider which itself changed to use OTLP instead of the Jaeger protocol. That required changing the former config settings (particularly the port).

Core Helidon PR helidon-io/helidon#11112 restores the Jaeger tracing provider to its former behavior, using the Jaeger protocol instead of OTLP, so this PR restores the example.

