### PR TITLE
Fix CORS example test to work with both current and new CORS approach

### DIFF
--- a/examples/microprofile/cors/src/test/java/io/helidon/microprofile/examples/cors/TestCORS.java
+++ b/examples/microprofile/cors/src/test/java/io/helidon/microprofile/examples/cors/TestCORS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import java.util.Optional;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
-import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
 import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.http.media.jsonb.JsonbSupport;
 import io.helidon.microprofile.server.Server;
 import io.helidon.webclient.http1.Http1Client;
@@ -31,14 +31,18 @@ import io.helidon.webclient.http1.Http1ClientResponse;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static io.helidon.cors.CrossOriginConfig.ACCESS_CONTROL_ALLOW_METHODS;
-import static io.helidon.cors.CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static io.helidon.http.HeaderNames.ACCESS_CONTROL_ALLOW_METHODS;
+import static io.helidon.http.HeaderNames.ACCESS_CONTROL_ALLOW_METHODS_NAME;
+import static io.helidon.http.HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static io.helidon.http.HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN_NAME;
+import static io.helidon.http.HeaderNames.ACCESS_CONTROL_REQUEST_METHOD;
+import static io.helidon.http.HeaderNames.HOST;
+import static io.helidon.http.HeaderNames.ORIGIN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -81,43 +85,43 @@ public class TestCORS {
 
         Http1ClientResponse r = getResponse("/greet");
 
-        assertThat("HTTP response1", r.status().code(), is(200));
+        assertThat("HTTP response1", r.status(), is(Status.OK_200));
         assertThat("default message", fromPayload(r), is("Hello World!"));
 
         r = getResponse("/greet/Joe");
-        assertThat("HTTP response2", r.status().code(), is(200));
+        assertThat("HTTP response2", r.status(), is(Status.OK_200));
         assertThat("Hello Joe message", fromPayload(r), is("Hello Joe!"));
 
         r = putResponse("/greet/greeting", "Hola");
-        assertThat("HTTP response3", r.status().code(), is(204));
+        assertThat("HTTP response3", r.status(), is(Status.NO_CONTENT_204));
 
         r = getResponse("/greet/Jose");
-        assertThat("HTTP response4", r.status().code(), is(200));
+        assertThat("HTTP response4", r.status(), is(Status.OK_200));
         assertThat("Hola Jose message", fromPayload(r), is("Hola Jose!"));
 
         r = getResponse("/health");
-        assertThat("HTTP response health", r.status().code(), is(200));
+        assertThat("HTTP response health", r.status(), is(Status.OK_200));
 
         r = getResponse("/metrics");
-        assertThat("HTTP response metrics", r.status().code(), is(200));
+        assertThat("HTTP response metrics", r.status(), is(Status.OK_200));
     }
 
     @Order(10) // Run after the non-CORS tests (so the greeting is Hola) but before the CORS test that changes the greeting again.
     @Test
     void testAnonymousGreetWithCors() {
         Http1ClientRequest req = client.get()
-                .header(HeaderNames.ORIGIN, "http://foo.com")
-                .header(HeaderNames.HOST, "here.com");
+                .header(ORIGIN, "http://foo.com")
+                .header(HOST, "here.com");
 
         Http1ClientResponse r = getResponse("/greet", req);
         assertThat("HTTP response", r.status().code(), is(200));
         String payload = fromPayload(r);
         assertThat("HTTP response payload", payload, is("Hola World!"));
         Headers responseHeaders = r.headers();
-        Optional<String> allowOrigin = responseHeaders.value(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN);
-        assertThat("Expected CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN + " is present",
+        Optional<String> allowOrigin = responseHeaders.value(ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat("Expected CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME + " is present",
                 allowOrigin.isPresent(), is(true));
-        assertThat("CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigin.get(), is("*"));
+        assertThat("CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME, allowOrigin.get(), is("*"));
     }
 
     @Order(11) // Run after the non-CORS tests but before other CORS tests.
@@ -127,57 +131,58 @@ public class TestCORS {
         // Send the pre-flight request and check the response.
 
         Http1ClientRequest req = client.method(Method.OPTIONS)
-                .header(HeaderNames.ORIGIN, "http://foo.com")
-                .header(HeaderNames.HOST, "here.com")
-                .header(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+                .header(ORIGIN, "http://foo.com")
+                .header(HOST, "here.com")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
 
         List<String> allowOrigins;
         Headers responseHeaders;
         Headers preflightResponseHeaders;
         try (Http1ClientResponse res = req.path("/greet/greeting").request()) {
-            assertThat("pre-flight status", res.status().code(), is(200));
+            assertThat("pre-flight status", res.status().family(), is(Status.Family.SUCCESSFUL));
             preflightResponseHeaders = res.headers();
         }
 
-        List<String> allowMethods = preflightResponseHeaders.values(HeaderNames.ACCESS_CONTROL_ALLOW_METHODS);
-        assertThat("pre-flight response check for " + ACCESS_CONTROL_ALLOW_METHODS, allowMethods, is(not(empty())));
-        assertThat("Header " + ACCESS_CONTROL_ALLOW_METHODS, allowMethods, contains("PUT"));
+        List<String> allowMethods = preflightResponseHeaders.values(ACCESS_CONTROL_ALLOW_METHODS);
+        assertThat("pre-flight response check for " + ACCESS_CONTROL_ALLOW_METHODS_NAME, allowMethods, is(not(empty())));
+        assertThat("Header " + ACCESS_CONTROL_ALLOW_METHODS_NAME, allowMethods, contains("PUT"));
 
-        allowOrigins = preflightResponseHeaders.values(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN);
+        allowOrigins = preflightResponseHeaders.values(ACCESS_CONTROL_ALLOW_ORIGIN);
 
-        assertThat("pre-flight response check for " + ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigins, is(not(empty())));
-        assertThat("Header " + ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigins, contains("http://foo.com"));
+        assertThat("pre-flight response check for " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME, allowOrigins, is(not(empty())));
+        assertThat("Header " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME, allowOrigins, contains("http://foo.com"));
 
         // Send the follow-up request.
 
         req = client.put()
-                .header(HeaderNames.ORIGIN, "http://foo.com")
-                .header(HeaderNames.HOST, "here.com");
+                .header(ORIGIN, "http://foo.com")
+                .header(HOST, "here.com");
         preflightResponseHeaders.forEach(req.headers()::add);
 
         try (Http1ClientResponse res = putResponse("/greet/greeting", "Cheers", req)) {
-            assertThat("HTTP response3", res.status().code(), is(204));
+            assertThat("HTTP response3", res.status(), is(Status.NO_CONTENT_204));
             responseHeaders = res.headers();
         }
 
-        allowOrigins = responseHeaders.values(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN);
-        assertThat("Expected CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigins, is(not(empty())));
-        assertThat("Header " + ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigins, contains("http://foo.com"));
+        allowOrigins = responseHeaders.values(ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat("Expected CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME, allowOrigins, is(not(empty())));
+        assertThat("Header " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME, allowOrigins, contains("http://foo.com"));
     }
 
     @Order(12) // Run after CORS test changes greeting to Cheers.
     @Test
     void testNamedGreetWithCors() {
         Http1ClientRequest req = client.get()
-                .header(HeaderNames.ORIGIN, "http://foo.com")
-                .header(HeaderNames.HOST, "here.com");
+                .header(ORIGIN, "http://foo.com")
+                .header(HOST, "here.com");
 
         Http1ClientResponse r = getResponse("/greet/Maria", req);
-        assertThat("HTTP response", r.status().code(), is(200));
+        assertThat("HTTP response", r.status(), is(Status.OK_200));
         assertThat(fromPayload(r), containsString("Cheers Maria"));
         Headers responseHeaders = r.headers();
-        Optional<String> allowOrigin = responseHeaders.value(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN);
-        assertThat("Expected CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN + " presence check", allowOrigin.isPresent(), is(true));
+        Optional<String> allowOrigin = responseHeaders.value(ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat("Expected CORS header " + ACCESS_CONTROL_ALLOW_ORIGIN_NAME + " presence check",
+                   allowOrigin.isPresent(), is(true));
         assertThat(allowOrigin.get(), is("*"));
     }
 
@@ -185,13 +190,13 @@ public class TestCORS {
     @Test
     void testGreetingChangeWithCorsAndOtherOrigin() {
         Http1ClientRequest req = client.put()
-                .header(HeaderNames.ORIGIN, "http://other.com")
-                .header(HeaderNames.HOST, "here.com");
+                .header(ORIGIN, "http://other.com")
+                .header(HOST, "here.com");
 
         try (Http1ClientResponse r = putResponse("/greet/greeting", "Ahoy", req)) {
             // Result depends on whether we are using overrides or not.
             boolean isOverriding = Config.create().get("cors").exists();
-            assertThat("HTTP response3", r.status().code(), is(isOverriding ? 204 : 403));
+            assertThat("HTTP response3", r.status(), is(isOverriding ? Status.NO_CONTENT_204 : Status.FORBIDDEN_403));
         }
     }
 


### PR DESCRIPTION
we will return 204 instead of 200 from pre-flight checks

This will allow PR https://github.com/helidon-io/helidon/pull/11155 to build examples without failure, and will not break build for other PRs.