### PR TITLE
Declarative metrics example should depend on helidon-http-media-json module.

### DIFF
--- a/examples/declarative/metrics/pom.xml
+++ b/examples/declarative/metrics/pom.xml
@@ -55,6 +55,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media-json-binding</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
As declarative metrics test uses JsonObject from helidon-json, it should depend on its media support helidon-http-media-json.