### PR TITLE
Remove use of deprecated WebServer APIs (27.x)

### DIFF
--- a/examples/webserver/protocols/src/main/java/io/helidon/examples/webserver/protocols/ProtocolsMain.java
+++ b/examples/webserver/protocols/src/main/java/io/helidon/examples/webserver/protocols/ProtocolsMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import java.util.Locale;
 
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
+import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.tls.Tls;
 import io.helidon.examples.grpc.strings.Strings;
+import io.helidon.grpc.core.ResponseHelper;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.grpc.GrpcRouting;
@@ -35,7 +37,6 @@ import io.helidon.websocket.WsSession;
 import io.grpc.stub.StreamObserver;
 
 import static io.helidon.http.Method.GET;
-import static io.helidon.webserver.grpc.ResponseHelper.complete;
 
 /**
  * Example showing supported protocols.
@@ -68,7 +69,8 @@ public class ProtocolsMain {
                            builder -> builder.port(8081)
                                    .host("127.0.0.1")
                                    .tls(tls)
-                                   .receiveBufferSize(4096)
+                                   .connectionOptions(SocketOptions.builder()
+                                                              .socketReceiveBufferSize(4096))
                                    .backlog(8192)
                 )
                 .routing(router -> router
@@ -89,7 +91,7 @@ public class ProtocolsMain {
     private static void grpcUpper(Strings.StringMessage request, StreamObserver<Strings.StringMessage> observer) {
         String requestText = request.getText();
         System.out.println("grpc request: " + requestText);
-        complete(observer, Strings.StringMessage.newBuilder()
+        ResponseHelper.complete(observer, Strings.StringMessage.newBuilder()
                 .setText(requestText.toUpperCase(Locale.ROOT))
                 .build());
     }

--- a/examples/webserver/protocols/src/main/java/io/helidon/examples/webserver/protocols/ProtocolsMain.java
+++ b/examples/webserver/protocols/src/main/java/io/helidon/examples/webserver/protocols/ProtocolsMain.java
@@ -24,7 +24,6 @@ import io.helidon.common.pki.Keys;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.tls.Tls;
 import io.helidon.examples.grpc.strings.Strings;
-import io.helidon.grpc.core.ResponseHelper;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.grpc.GrpcRouting;
@@ -36,6 +35,7 @@ import io.helidon.websocket.WsSession;
 
 import io.grpc.stub.StreamObserver;
 
+import static io.helidon.grpc.core.ResponseHelper.complete;
 import static io.helidon.http.Method.GET;
 
 /**
@@ -91,7 +91,7 @@ public class ProtocolsMain {
     private static void grpcUpper(Strings.StringMessage request, StreamObserver<Strings.StringMessage> observer) {
         String requestText = request.getText();
         System.out.println("grpc request: " + requestText);
-        ResponseHelper.complete(observer, Strings.StringMessage.newBuilder()
+        complete(observer, Strings.StringMessage.newBuilder()
                 .setText(requestText.toUpperCase(Locale.ROOT))
                 .build());
     }


### PR DESCRIPTION
Resolves #271

Updates the protocols example to use the supported listener socket-options API
and the current gRPC response helper.
