### PR TITLE
Remove use of deprecated Security APIs (27.x)

### DIFF
--- a/examples/security/spi-examples/src/main/java/io/helidon/security/examples/spi/AtnProviderImpl.java
+++ b/examples/security/spi-examples/src/main/java/io/helidon/security/examples/spi/AtnProviderImpl.java
@@ -16,25 +16,22 @@
 
 package io.helidon.security.examples.spi;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.types.TypeName;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.Principal;
 import io.helidon.security.ProviderRequest;
 import io.helidon.security.Role;
-import io.helidon.security.SecurityLevel;
 import io.helidon.security.Subject;
 import io.helidon.security.spi.AuthenticationProvider;
 
@@ -43,6 +40,8 @@ import io.helidon.security.spi.AuthenticationProvider;
  * This is a full-blown example of a provider that requires additional configuration on a resource.
  */
 public class AtnProviderImpl implements AuthenticationProvider {
+    private static final TypeName ATN_ANNOTATION = TypeName.create(AtnAnnot.class);
+
     @Override
     public AuthenticationResponse authenticate(ProviderRequest providerRequest) {
 
@@ -82,19 +81,18 @@ public class AtnProviderImpl implements AuthenticationProvider {
         }
 
         // 3) annotations on target
-        List<AtnAnnot> annots = new ArrayList<>();
-        for (SecurityLevel securityLevel : epConfig.securityLevels()) {
-            annots.addAll(securityLevel.combineAnnotations(AtnAnnot.class, EndpointConfig.AnnotationScope.values()));
-        }
-        if (annots.isEmpty()) {
-            return null;
-        } else {
-            return AtnObject.from(annots.get(0));
-        }
+        return epConfig.securityLevels()
+                .stream()
+                .flatMap(securityLevel -> securityLevel.combineAnnotations(ATN_ANNOTATION,
+                                                                           EndpointConfig.AnnotationScope.values())
+                        .stream())
+                .findFirst()
+                .map(AtnObject::from)
+                .orElse(null);
     }
 
     @Override
-    public Collection<Class<? extends Annotation>> supportedAnnotations() {
+    public Collection<Class<? extends java.lang.annotation.Annotation>> supportedAnnotations() {
         return Set.of(AtnAnnot.class);
     }
 
@@ -141,10 +139,10 @@ public class AtnProviderImpl implements AuthenticationProvider {
             return result;
         }
 
-        static AtnObject from(AtnAnnot annot) {
+        static AtnObject from(io.helidon.common.types.Annotation annot) {
             AtnObject result = new AtnObject();
-            result.setValue(annot.value());
-            result.setSize(annot.size());
+            result.setValue(annot.stringValue().orElseThrow());
+            result.setSize(annot.intValue("size").orElse(4));
             return result;
         }
 

--- a/examples/security/spi-examples/src/test/java/io/helidon/security/examples/spi/AtnProviderSyncTest.java
+++ b/examples/security/spi-examples/src/test/java/io/helidon/security/examples/spi/AtnProviderSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/security/spi-examples/src/test/java/io/helidon/security/examples/spi/AtnProviderSyncTest.java
+++ b/examples/security/spi-examples/src/test/java/io/helidon/security/examples/spi/AtnProviderSyncTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.types.TypeName;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.security.AuthenticationResponse;
@@ -95,8 +96,9 @@ public class AtnProviderSyncTest {
 
         SecurityEnvironment se = SecurityEnvironment.create();
 
-        SecurityLevel level = SecurityLevel.create("mock")
-                .withClassAnnotations(Map.of(AtnProviderImpl.AtnAnnot.class, List.of(annot)))
+        SecurityLevel level = SecurityLevel.builder()
+                .type(TypeName.create("mock"))
+                .addClassAnnotation(annot)
                 .build();
 
         EndpointConfig ep = EndpointConfig.builder()


### PR DESCRIPTION
Resolves #273

Update the security SPI example to use the current SecurityLevel annotation APIs and align the SPI test with the current builder methods.
