### PR TITLE
Disable keep-alive on SSE tests

### DIFF
--- a/examples/webserver/sse/src/test/java/io/helidon/examples/webserver/sse/SseServiceTest.java
+++ b/examples/webserver/sse/src/test/java/io/helidon/examples/webserver/sse/SseServiceTest.java
@@ -58,6 +58,7 @@ class SseServiceTest {
                 .queryParam("count", "3")
                 .header(ACCEPT_EVENT_STREAM)
                 .header(ACCEPT_ENCODING, encoding)
+                .keepAlive(false)       // avoids race of connection reuse vs close
                 .request()) {
             var latch = new CountDownLatch(3);
             var events = new ArrayList<SseEvent>();
@@ -83,6 +84,7 @@ class SseServiceTest {
                 .queryParam("count", "3")
                 .header(ACCEPT_EVENT_STREAM)
                 .header(ACCEPT_ENCODING, encoding)
+                .keepAlive(false)       // avoids race of connection reuse vs close
                 .request()) {
             var latch = new CountDownLatch(3);
             var events = new ArrayList<JsonObject>();


### PR DESCRIPTION
## Description

Disable keep-alive on SSE test requests so parameterized runs do not reuse a connection the server has already closed after the stream completes. This avoids an intermittent race that surfaced as `InsufficientDataAvailableException` while reading the next HTTP status line. See issue #268.