### PR TITLE
Fix tracing example deprecations (27.x)

### DIFF
--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.http.Status;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
@@ -69,7 +69,7 @@ public class GreetService implements HttpService {
         Config config = Services.get(Config.class);
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
 
-        MeterRegistry meterRegistry = Metrics.globalRegistry();
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
         timerForGets = meterRegistry.getOrCreate(Timer.builder(TIMER_FOR_GETS)
                                                          .baseUnit(Meter.BaseUnits.NANOSECONDS));
         personalizedGreetingsCounter = meterRegistry.getOrCreate(Counter.builder(COUNTER_FOR_PERSONALIZED_GREETINGS));

--- a/examples/webserver/tracing/README.md
+++ b/examples/webserver/tracing/README.md
@@ -1,0 +1,85 @@
+# Helidon WebServer Tracing Example
+
+This project demonstrates Helidon SE server and client tracing using the `tracing` configuration together with the OpenTelemetry tracing provider.
+
+The example exposes a version-specific route and a client route:
+
+* `GET /versionspecific` returns different text for HTTP/1.1 and HTTP/2 requests.
+* `GET /client` uses a traced `WebClient` call to invoke `/versionspecific` and also creates a manual `custom-span`.
+
+## Start a tracing back-end
+
+Run Jaeger with OTLP enabled so the example can export spans using the default OpenTelemetry gRPC endpoint on `localhost:4317`.
+
+```bash
+docker run -d --rm --name helidon-examples-jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  jaegertracing/all-in-one:1.50
+```
+
+## View the tracing configuration
+
+Look at `src/main/resources/application.yaml`.
+
+The example keeps the same service and sampling behavior as before and makes the OpenTelemetry exporter choice explicit:
+
+* `service` identifies the traced application in Jaeger as `helidon-server`.
+* `sampler-type` and `sampler-param` keep tracing enabled for every request. The OpenTelemetry provider uses `constant` for the same always-sample behavior that the old Jaeger configuration expressed as `const`.
+* `exporter-type: grpc` sends spans using OTLP gRPC. The example relies on the default collector settings, so Jaeger only needs OTLP enabled on `localhost:4317`.
+
+## Build and run
+
+With JDK 26:
+
+```bash
+mvn package
+java -jar target/helidon-examples-webserver-tracing.jar
+```
+
+## Exercise the application
+
+HTTP/1.1 route:
+
+```bash
+curl http://localhost:8080/versionspecific
+```
+
+Expected response:
+
+```text
+HTTP/1.1 route
+```
+
+HTTP/2 route:
+
+```bash
+curl --http2-prior-knowledge http://localhost:8080/versionspecific
+```
+
+Expected response:
+
+```text
+HTTP/2 route
+```
+
+Traced client route:
+
+```bash
+curl http://localhost:8080/client
+```
+
+Expected response:
+
+```text
+HTTP/1.1 route
+```
+
+## View traces in Jaeger
+
+1. Open `http://localhost:16686`.
+2. Select the `helidon-server` service and run a search.
+3. Open a trace created by `GET /client`.
+
+The trace should include the incoming server span, the outgoing traced `WebClient` call, and the manual `custom-span`.

--- a/examples/webserver/tracing/pom.xml
+++ b/examples/webserver/tracing/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing.providers</groupId>
-            <artifactId>helidon-tracing-providers-jaeger</artifactId>
+            <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/examples/webserver/tracing/src/main/java/io/helidon/examples/webserver/tracing/TracingMain.java
+++ b/examples/webserver/tracing/src/main/java/io/helidon/examples/webserver/tracing/TracingMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.examples.webserver.tracing;
 
+import io.helidon.config.Config;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.Tracer;
@@ -47,7 +48,8 @@ public class TracingMain {
     public static void main(String[] args) {
         LogConfig.configureRuntime();
 
-        Tracer tracer = TracerBuilder.create("helidon")
+        Config config = Config.global();
+        Tracer tracer = TracerBuilder.create(config.get("tracing"))
                 .build();
 
         WebServer.builder()

--- a/examples/webserver/tracing/src/main/resources/application.yaml
+++ b/examples/webserver/tracing/src/main/resources/application.yaml
@@ -16,6 +16,6 @@
 
 tracing:
   service: "helidon-server"
-  sampler-type: "const"
+  sampler-type: "constant"
   sampler-param: 1
   exporter-type: grpc

--- a/examples/webserver/tracing/src/main/resources/application.yaml
+++ b/examples/webserver/tracing/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,3 +18,4 @@ tracing:
   service: "helidon-server"
   sampler-type: "const"
   sampler-param: 1
+  exporter-type: grpc


### PR DESCRIPTION
Resolves #277

Replaces the deprecated Jaeger tracing provider in the webserver tracing example with the OpenTelemetry provider, updates the tracing config to the OpenTelemetry-equivalent sampler setting, and adds a README with Jaeger OTLP verification steps.

Also replaces the deprecated metrics global-registry shortcut in the tracing-related exemplar sample with `MetricsFactory`.

References:
- helidon-io/helidon#11485
- helidon-io/helidon#11486
