### PR TITLE
4.x: Samples: APM service integration

### DIFF
--- a/examples/telemetry/apm/README.md
+++ b/examples/telemetry/apm/README.md
@@ -1,0 +1,97 @@
+# Helidon OpenTelemetry to Oracle APM Example
+
+This example shows how to configure a Helidon SE service so it exports OpenTelemetry tracing data to Oracle Application Performance Monitoring (APM) using OTLP over HTTP.
+
+The application code does not call the OpenTelemetry API directly. Helidon prepares the OpenTelemetry SDK from configuration, and the webserver observe tracing integration emits spans for incoming HTTP requests automatically.
+
+## Dependencies to add
+
+The example POM includes the Helidon and OpenTelemetry pieces needed for this setup:
+
+```xml
+<dependency>
+    <groupId>io.helidon.telemetry</groupId>
+    <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.helidon.webserver.observe</groupId>
+    <artifactId>helidon-webserver-observe-tracing</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.helidon.tracing.providers</groupId>
+    <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
+    <groupId>io.helidon.webserver.observe</groupId>
+    <artifactId>helidon-webserver-observe-telemetry-tracing</artifactId>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-exporter-otlp</artifactId>
+    <scope>runtime</scope>
+</dependency>
+```
+
+## Configuration to add
+
+Look at `src/main/resources/application.yaml`. The important settings are:
+
+* `telemetry.service` assigns the service name shown later in Oracle APM.
+* `telemetry.signals.tracing.exporters` configures an OTLP exporter using `http/proto`, which matches Oracle APM's OTLP HTTP ingestion.
+* `telemetry.signals.tracing.exporters.headers.Authorization` sends the required `dataKey` header.
+* `telemetry.signals.tracing.processors` uses the `simple` processor so the example exports spans immediately. For production systems, prefer the default `batch` processor.
+
+The configuration uses environment variables so you can point the same application at your Oracle APM domain without code changes:
+
+* `APM_TRACES_ENDPOINT` must be the full Oracle APM traces OTLP endpoint, such as:
+  * private data key: `https://<apm-data-upload-endpoint>/20200101/opentelemetry/private/v1/traces`
+  * public data key: `https://<apm-data-upload-endpoint>/20200101/opentelemetry/public/v1/traces`
+* `APM_DATA_KEY` is the matching Oracle APM data key value.
+
+## Build and run
+
+With JDK 21:
+
+```bash
+export APM_TRACES_ENDPOINT="https://<apm-data-upload-endpoint>/20200101/opentelemetry/private/v1/traces"
+export APM_DATA_KEY="<oracle-apm-data-key>"
+mvn package
+java -jar target/helidon-examples-telemetry-apm.jar
+```
+
+## Exercise the application
+
+Basic:
+
+```bash
+curl -X GET http://localhost:8080/simple-greet
+Hello World!
+```
+
+JSON:
+
+```bash
+curl -X GET http://localhost:8080/greet
+{"message":"Hello World!"}
+
+curl -X GET http://localhost:8080/greet/Joe
+{"message":"Hello Joe!"}
+
+curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
+
+curl -X GET http://localhost:8080/greet/Jose
+{"message":"Hola Jose!"}
+```
+
+## Verify data in Oracle APM
+
+After sending a few requests, open Oracle APM and look for traces from service `helidon-apm-example`.
+
+Each HTTP request should create a trace for this service. In the trace details you should also see the resource attributes configured in `application.yaml`, including `deployment.environment=example` and `telemetry.backend=oracle-apm`.
+
+For more detail on the Oracle APM endpoint and data key requirements, see the
+[Oracle APM documentation for ingesting OpenTelemetry data](https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html)
+and the
+[Helidon documentation for OpenTelemetry configuration](https://helidon.io/docs/latest/se/telemetry/open-telemetry).

--- a/examples/telemetry/apm/pom.xml
+++ b/examples/telemetry/apm/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>4.4.1</version>
+        <relativePath/>
+    </parent>
+    <groupId>io.helidon.examples.telemetry</groupId>
+    <artifactId>helidon-examples-telemetry-apm</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Helidon OpenTelemetry Oracle APM Example</name>
+    <description>Helidon SE example that exports OpenTelemetry tracing data to Oracle APM using OTLP/HTTP.</description>
+
+    <properties>
+        <mainClass>io.helidon.examples.telemetry.apm.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.telemetry</groupId>
+            <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jsonp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing.providers</groupId>
+            <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-telemetry-tracing</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.telemetry.testing</groupId>
+            <artifactId>helidon-telemetry-testing-tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/telemetry/apm/src/main/java/io/helidon/examples/telemetry/apm/GreetService.java
+++ b/examples/telemetry/apm/src/main/java/io/helidon/examples/telemetry/apm/GreetService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.telemetry.apm;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.config.Config;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+
+/**
+ * A simple service to greet you. Examples:
+ * <p>
+ * Get default greeting message:
+ * {@code curl -X GET http://localhost:8080/greet}
+ * <p>
+ * Get greeting message for Joe:
+ * {@code curl -X GET http://localhost:8080/greet/Joe}
+ * <p>
+ * Change greeting
+ * {@code curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Howdy"}' http://localhost:8080/greet/greeting}
+ * <p>
+ * The message is returned as a JSON object
+ */
+class GreetService implements HttpService {
+
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    /**
+     * The config value for the key {@code greeting}.
+     */
+    private final AtomicReference<String> greeting = new AtomicReference<>();
+
+    GreetService() {
+        this(Config.global().get("app"));
+    }
+
+    GreetService(Config appConfig) {
+        greeting.set(appConfig.get("greeting").asString().orElse("Ciao"));
+    }
+
+    /**
+     * A service registers itself by updating the routing rules.
+     *
+     * @param rules the routing rules.
+     */
+    @Override
+    public void routing(HttpRules rules) {
+        rules
+                .get("/", this::getDefaultMessageHandler)
+                .get("/{name}", this::getMessageHandler)
+                .put("/greeting", this::updateGreetingHandler);
+    }
+
+    /**
+     * Return a worldly greeting message.
+     *
+     * @param request  the server request
+     * @param response the server response
+     */
+    private void getDefaultMessageHandler(ServerRequest request,
+                                          ServerResponse response) {
+        sendResponse(response, "World");
+    }
+
+    /**
+     * Return a greeting message using the name that was provided.
+     *
+     * @param request  the server request
+     * @param response the server response
+     */
+    private void getMessageHandler(ServerRequest request,
+                                   ServerResponse response) {
+        String name = request.path().pathParameters().get("name");
+        sendResponse(response, name);
+    }
+
+    private void sendResponse(ServerResponse response, String name) {
+        String msg = String.format("%s %s!", greeting.get(), name);
+
+        JsonObject returnObject = JSON.createObjectBuilder()
+                .add("message", msg)
+                .build();
+        response.send(returnObject);
+    }
+
+    private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
+
+        if (!jo.containsKey("greeting")) {
+            JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            response.status(Status.BAD_REQUEST_400)
+                    .send(jsonErrorObject);
+            return;
+        }
+
+        greeting.set(jo.getString("greeting"));
+        response.status(Status.NO_CONTENT_204).send();
+    }
+
+    /**
+     * Set the greeting to use in future messages.
+     *
+     * @param request  the server request
+     * @param response the server response
+     */
+    private void updateGreetingHandler(ServerRequest request,
+                                       ServerResponse response) {
+        updateGreetingFromJson(request.content().as(JsonObject.class), response);
+    }
+
+}

--- a/examples/telemetry/apm/src/main/java/io/helidon/examples/telemetry/apm/Main.java
+++ b/examples/telemetry/apm/src/main/java/io/helidon/examples/telemetry/apm/Main.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.telemetry.apm;
+
+import io.helidon.config.Config;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.Services;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+
+/**
+ * The application main class.
+ *
+ * <p>The service code is plain Helidon SE. Tracing is activated by the runtime
+ * dependencies plus the {@code telemetry} configuration in {@code application.yaml}.
+ */
+public class Main {
+
+    /**
+     * Cannot be instantiated.
+     */
+    private Main() {
+    }
+
+    /**
+     * Application main entry point.
+     * @param args command line arguments.
+     */
+    public static void main(String[] args) {
+
+        // load logging configuration
+        LogConfig.configureRuntime();
+
+        // initialize config from default configuration
+        Config config = Services.get(Config.class);
+
+        WebServer server = WebServer.builder()
+                .config(config.get("server"))
+                .routing(Main::routing)
+                .build()
+                .start();
+
+        System.out.println("WEB server is up! http://localhost:" + server.port() + "/simple-greet");
+
+    }
+
+    /**
+     * Updates HTTP Routing.
+     */
+    static void routing(HttpRouting.Builder routing) {
+        routing
+                .register("/greet", new GreetService())
+                .get("/simple-greet", (req, res) -> res.send("Hello World!"));
+    }
+}

--- a/examples/telemetry/apm/src/main/java/io/helidon/examples/telemetry/apm/package-info.java
+++ b/examples/telemetry/apm/src/main/java/io/helidon/examples/telemetry/apm/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OpenTelemetry to Oracle APM example.
+ */
+package io.helidon.examples.telemetry.apm;

--- a/examples/telemetry/apm/src/main/resources/META-INF/native-image/io/helidon/examples/telemetry/helidon-examples-telemetry-apm/native-image.properties
+++ b/examples/telemetry/apm/src/main/resources/META-INF/native-image/io/helidon/examples/telemetry/helidon-examples-telemetry-apm/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args=--initialize-at-build-time=io.helidon.examples.telemetry.apm

--- a/examples/telemetry/apm/src/main/resources/application.yaml
+++ b/examples/telemetry/apm/src/main/resources/application.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+  host: 0.0.0.0
+app:
+    greeting: "Hello"
+telemetry:
+  service: "helidon-apm-example"
+  signals:
+    tracing:
+      attributes:
+        strings:
+          deployment.environment: "example"
+          telemetry.backend: "oracle-apm"
+        longs:
+          example.revision: 1
+      exporters:
+        - name: oracle-apm
+          type: otlp
+          protocol: http/proto
+          endpoint: "${APM_TRACES_ENDPOINT:http://localhost:4318/v1/traces}"
+          headers:
+            Authorization: "dataKey ${APM_DATA_KEY:replace-with-your-data-key}"
+      processors:
+        - type: simple
+          exporters: ["oracle-apm"]

--- a/examples/telemetry/apm/src/main/resources/logging.properties
+++ b/examples/telemetry/apm/src/main/resources/logging.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+io.helidon.level=INFO

--- a/examples/telemetry/apm/src/test/java/io/helidon/examples/telemetry/apm/MainTest.java
+++ b/examples/telemetry/apm/src/test/java/io/helidon/examples/telemetry/apm/MainTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.telemetry.apm;
+
+import java.util.List;
+
+import io.helidon.http.Status;
+import io.helidon.telemetry.testing.tracing.JsonLogConverter;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webserver.testing.junit5.DirectClient;
+import io.helidon.webserver.testing.junit5.RoutingTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.http.HttpRouting;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+
+@RoutingTest
+class MainTest {
+    private final DirectClient client;
+
+    MainTest(DirectClient client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        Main.routing(builder);
+    }
+
+    @Test
+    void testGreeting() {
+        ClientResponseTyped<JsonObject> response = client.get("/greet").request(JsonObject.class);
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity().getString("message"), is("Hello World!"));
+    }
+
+    @Test
+    void testSimpleGreet() {
+        ClientResponseTyped<String> response = client.get("/simple-greet").request(String.class);
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("Hello World!"));
+    }
+
+    @Test
+    void testSpanForNamedGreeting() throws Exception {
+        try (JsonLogConverter converter = JsonLogConverter.create()) {
+            ClientResponseTyped<JsonObject> response = client.get("/greet/Joe").request(JsonObject.class);
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().getString("message"), is("Hello Joe!"));
+
+            List<JsonLogConverter.LogResourceScopeSpans> scopeSpans = converter.resourceSpans(2);
+
+            for (var scopeSpan : scopeSpans) {
+                assertThat("String attributes",
+                           scopeSpan.resource().attributes(),
+                           allOf(hasEntry("service.name", "helidon-apm-example"),
+                                 hasEntry("deployment.environment", "example"),
+                                 hasEntry("telemetry.backend", "oracle-apm")));
+                assertThat("Numeric attributes",
+                           scopeSpan.resource().attributes(),
+                           hasEntry("example.revision", 1));
+            }
+
+            var childSpan = scopeSpans.get(0).scopeSpans().getFirst().logSpans().getFirst();
+            var parentSpan = scopeSpans.get(1).scopeSpans().getFirst().logSpans().getFirst();
+
+            assertThat("Parent of child span", childSpan.parentSpanId(), is(parentSpan.spanId()));
+        }
+    }
+}

--- a/examples/telemetry/apm/src/test/resources/application-test.yaml
+++ b/examples/telemetry/apm/src/test/resources/application-test.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+telemetry:
+  service: "helidon-apm-example"
+  signals:
+    tracing:
+      attributes:
+        strings:
+          deployment.environment: "example"
+          telemetry.backend: "oracle-apm"
+        longs:
+          example.revision: 1
+      processors:
+        - type: simple
+      exporters:
+        - type: logging_otlp

--- a/examples/telemetry/pom.xml
+++ b/examples/telemetry/pom.xml
@@ -32,6 +32,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>apm</module>
         <module>config</module>
         <module>otel</module>
     </modules>


### PR DESCRIPTION
Adds a new examples/telemetry/apm example showing how to export Helidon SE tracing data to Oracle APM using Helidon’s OpenTelemetry OTLP/HTTP configuration.
