### PR TITLE
Fix config metadata coordinates in examples (27.x)

### DIFF
--- a/examples/config/metadata/pom.xml
+++ b/examples/config/metadata/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>parsson</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
     </dependencies>

--- a/examples/dbclient/tracing/pom.xml
+++ b/examples/dbclient/tracing/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Resolves #289

Update the affected example POMs to use the new `io.helidon.config.metadata`
group id for `helidon-config-metadata`, so the config metadata and dbclient
tracing examples resolve the dependency again on `dev-27.x`.
