### PR TITLE
Update config metadata coordinates in examples (4.x)

### DIFF
--- a/examples/config/metadata/pom.xml
+++ b/examples/config/metadata/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>parsson</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
     </dependencies>

--- a/examples/dbclient/tracing/pom.xml
+++ b/examples/dbclient/tracing/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Resolves #291

Backport `helidon-io/helidon-examples#290` to `dev-4.x` so the config
metadata and dbclient tracing examples use the current
`io.helidon.config.metadata` group id.

This is not a 4.x breakage because the compatibility layer still resolves the
old coordinate, but aligning the examples keeps the branch in sync with the
newer line.
