### PR TITLE
Add declarative tracing example (27.x)

### DIFF
--- a/examples/declarative/pom.xml
+++ b/examples/declarative/pom.xml
@@ -39,6 +39,7 @@
         <module>scheduling</module>
         <module>fault-tolerance</module>
         <module>metrics</module>
+        <module>tracing</module>
         <module>validation</module>
         <module>data</module>
         <module>security</module>

--- a/examples/declarative/tracing/README.md
+++ b/examples/declarative/tracing/README.md
@@ -1,0 +1,109 @@
+# Declarative Server Example with Tracing
+
+This example shows how to use Helidon Declarative tracing annotations together with the Helidon `telemetry`
+configuration. The application uses the OpenTelemetry-based Helidon telemetry integration and exports spans directly to
+Zipkin.
+
+## Start Zipkin
+
+Run Zipkin so the example can export spans to `http://localhost:9411/api/v2/spans`.
+
+```bash
+docker run -d --rm --name helidon-examples-zipkin \
+  -p 9411:9411 \
+  openzipkin/zipkin:3.5.1
+```
+
+## View the telemetry configuration
+
+Look at `src/main/resources/application.yaml`.
+
+The important settings are:
+
+* `telemetry.service` sets the service name shown in Zipkin to `helidon-examples-declarative-tracing`.
+* `telemetry.signals.tracing.processors` uses the `simple` processor so spans are exported immediately while you exercise
+  the example.
+* `telemetry.signals.tracing.exporters` selects the `zipkin` exporter and points it at the default Zipkin v2 HTTP API.
+
+The endpoint methods are annotated with `@Tracing.Traced`, and selected request values are added to spans using
+`@Tracing.ParamTag`.
+
+## Build and run
+
+Build this application:
+
+```bash
+mvn package
+```
+
+Run from the command line:
+
+```bash
+java -jar target/helidon-examples-declarative-tracing.jar
+```
+
+The server prints a URL similar to:
+
+```text
+Server started on: http://localhost:8080/hello
+```
+
+## Exercise the application
+
+Greeting:
+
+```bash
+curl -H 'User-Agent: declarative-demo' http://localhost:8080/hello
+```
+
+Expected output:
+
+```text
+Hello World
+```
+
+Named greeting:
+
+```bash
+curl -H 'User-Agent: declarative-demo' http://localhost:8080/hello/Joe
+```
+
+Expected output:
+
+```text
+Hello Joe
+```
+
+Update the greeting:
+
+```bash
+curl -X POST -H 'Content-Type: text/plain' -d 'Hola' http://localhost:8080/hello
+curl -H 'User-Agent: declarative-demo' http://localhost:8080/hello/Jose
+```
+
+Expected output:
+
+```text
+Hola Jose
+```
+
+## View traces in Zipkin
+
+1. Open `http://localhost:9411/zipkin/`.
+2. Select the `helidon-examples-declarative-tracing` service and run a search.
+3. Open one of the traces created by the `GET /hello` or `GET /hello/{name}` requests.
+
+The trace should include:
+
+* the incoming `GET` or `POST` span created by WebServer tracing,
+* the `content-write` span for the response, and
+* the declarative method span such as `greet-world` or `greet-name`.
+
+The declarative method span also carries tags from the tracing annotations, including the `route` tag and the
+`userAgent` parameter tag.
+
+## Stop Zipkin
+
+```bash
+docker stop helidon-examples-zipkin
+```

--- a/examples/declarative/tracing/README.md
+++ b/examples/declarative/tracing/README.md
@@ -2,16 +2,16 @@
 
 This example shows how to use Helidon Declarative tracing annotations together with the Helidon `telemetry`
 configuration. The application uses the OpenTelemetry-based Helidon telemetry integration and exports spans directly to
-Zipkin.
+Zipkin using OTLP.
 
 ## Start Zipkin
 
-Run Zipkin so the example can export spans to `http://localhost:9411/api/v2/spans`.
+Run Zipkin so the example can export spans using OTLP.
 
 ```bash
 docker run -d --rm --name helidon-examples-zipkin \
   -p 9411:9411 \
-  openzipkin/zipkin:3.5.1
+  ghcr.io/openzipkin-contrib/zipkin-otel
 ```
 
 ## View the telemetry configuration
@@ -23,7 +23,8 @@ The important settings are:
 * `telemetry.service` sets the service name shown in Zipkin to `helidon-examples-declarative-tracing`.
 * `telemetry.signals.tracing.processors` uses the `simple` processor so spans are exported immediately while you exercise
   the example.
-* `telemetry.signals.tracing.exporters` selects the `zipkin` exporter and points it at the default Zipkin v2 HTTP API.
+* `telemetry.signals.tracing.exporters` selects the `otlp` exporter using the `http/proto` protocol and the Zipkin OTLP
+  HTTP endpoint at `http://localhost:9411/v1/traces`.
 
 The endpoint methods are annotated with `@Tracing.Traced`, and selected request values are added to spans using
 `@Tracing.ParamTag`.

--- a/examples/declarative/tracing/pom.xml
+++ b/examples/declarative/tracing/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/examples/declarative/tracing/pom.xml
+++ b/examples/declarative/tracing/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.examples.declarative.tracing</groupId>
+    <artifactId>helidon-examples-declarative-tracing</artifactId>
+    <name>Helidon Examples Declarative Tracing</name>
+
+    <properties>
+        <mainClass>io.helidon.examples.declarative.tracing.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.telemetry</groupId>
+            <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing.providers</groupId>
+            <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-telemetry-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.telemetry.testing</groupId>
+            <artifactId>helidon-telemetry-testing-tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.bundles</groupId>
+                            <artifactId>helidon-bundles-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.helidon.service</groupId>
+                <artifactId>helidon-service-maven-plugin</artifactId>
+                <version>${helidon.version}</version>
+                <executions>
+                    <execution>
+                        <id>create-application</id>
+                        <goals>
+                            <goal>create-application</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
+++ b/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.declarative.tracing;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.Api;
+import io.helidon.common.Default;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Configuration;
+import io.helidon.http.Http;
+import io.helidon.http.Status;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+import io.helidon.webserver.http.RestServer;
+
+@SuppressWarnings(Api.SUPPRESS_INCUBATING)
+@RestServer.Endpoint
+@Http.Path("/hello")
+@Service.Singleton
+@Tracing.Traced(tags = @Tracing.Tag(key = "example", value = "declarative-tracing"), kind = Span.Kind.SERVER)
+class HelloWorldEndpoint {
+    private final AtomicReference<String> greeting = new AtomicReference<>();
+
+    @Service.Inject
+    HelloWorldEndpoint(@Default.Value("Hello") @Configuration.Value("app.greeting") String greeting) {
+        this.greeting.set(greeting);
+    }
+
+    @Http.GET
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    @Tracing.Traced(value = "greet-world", tags = @Tracing.Tag(key = "route", value = "world"))
+    String hello(@Http.HeaderParam("User-Agent") @Tracing.ParamTag String userAgent) {
+        return greeting.get() + " World";
+    }
+
+    @Http.GET
+    @Http.Path("/{name}")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    @Tracing.Traced(value = "greet-name", tags = @Tracing.Tag(key = "route", value = "named"))
+    String hello(@Http.PathParam("name") String name,
+                 @Http.HeaderParam("User-Agent") @Tracing.ParamTag String userAgent) {
+        return greeting.get() + " " + name;
+    }
+
+    @Http.POST
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @RestServer.Status(Status.NO_CONTENT_204_CODE)
+    @Tracing.Traced(value = "update-greeting", tags = @Tracing.Tag(key = "route", value = "update"))
+    void updateGreeting(@Http.Entity String newGreeting) {
+        greeting.set(newGreeting);
+    }
+}

--- a/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/Main.java
+++ b/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/Main.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.declarative.tracing;
+
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.webserver.WebServer;
+
+/**
+ * Main class responsible for starting the service registry.
+ * <p>
+ * This class is annotated with {@link io.helidon.service.registry.Service.GenerateBinding}, which (when used in combination
+ * with Helidon Maven Plugin) generates a binding class that can be used to bootstrap Helidon without usage of reflection
+ * and classpath lookup during discovery of services.
+ */
+@Service.GenerateBinding
+public class Main {
+    static {
+        LogConfig.initClass();
+    }
+
+    private Main() {
+    }
+
+    /**
+     * Application main entry point.
+     *
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+        ServiceRegistryManager.start(ApplicationBinding.create());
+
+        WebServer webServer = Services.get(WebServer.class);
+        System.out.println("Server started on: http://localhost:" + webServer.port() + "/hello");
+    }
+}

--- a/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/package-info.java
+++ b/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon SE Declarative Tracing example.
+ */
+package io.helidon.examples.declarative.tracing;

--- a/examples/declarative/tracing/src/main/resources/application.yaml
+++ b/examples/declarative/tracing/src/main/resources/application.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+  host: 0.0.0.0
+
+declarative:
+  ignore-incubating: true
+
+app:
+  greeting: "Hello"
+
+telemetry:
+  service: "helidon-examples-declarative-tracing"
+  signals:
+    tracing:
+      processors:
+        - type: simple
+      exporters:
+        - type: zipkin
+          endpoint: "http://localhost:9411/api/v2/spans"

--- a/examples/declarative/tracing/src/main/resources/application.yaml
+++ b/examples/declarative/tracing/src/main/resources/application.yaml
@@ -31,5 +31,6 @@ telemetry:
       processors:
         - type: simple
       exporters:
-        - type: zipkin
-          endpoint: "http://localhost:9411/api/v2/spans"
+        - type: otlp
+          protocol: http/proto
+          endpoint: "http://localhost:9411/v1/traces"

--- a/examples/declarative/tracing/src/main/resources/logging.properties
+++ b/examples/declarative/tracing/src/main/resources/logging.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+
+.level=INFO
+io.helidon.level=INFO

--- a/examples/declarative/tracing/src/test/java/io/helidon/examples/declarative/tracing/DeclarativeTracingTest.java
+++ b/examples/declarative/tracing/src/test/java/io/helidon/examples/declarative/tracing/DeclarativeTracingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.declarative.tracing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.telemetry.testing.tracing.JsonLogConverter;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
+
+@ServerTest
+class DeclarativeTracingTest {
+    private final Http1Client client;
+
+    DeclarativeTracingTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @Test
+    void testNamedGreetingTracing() throws Exception {
+        String userAgent = "DeclarativeTracingTest";
+
+        try (JsonLogConverter converter = JsonLogConverter.create()) {
+            var response = client.get("/hello/Joe")
+                    .accept(MediaTypes.TEXT_PLAIN)
+                    .header(HeaderNames.USER_AGENT, userAgent)
+                    .request(String.class);
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity(), is("Hello Joe"));
+
+            List<JsonLogConverter.LogSpan> spans = spans(converter.resourceSpans(3));
+
+            Map<String, JsonLogConverter.LogSpan> spansByName = spans.stream()
+                    .collect(Collectors.toMap(JsonLogConverter.LogSpan::name, span -> span));
+
+            JsonLogConverter.LogSpan httpRequest = spansByName.get("GET");
+            JsonLogConverter.LogSpan contentWrite = spansByName.get("content-write");
+            JsonLogConverter.LogSpan greetName = spansByName.get("greet-name");
+
+            assertThat(httpRequest, notNullValue());
+            assertThat(contentWrite, notNullValue());
+            assertThat(greetName, notNullValue());
+            assertThat(httpRequest.traceId(), is(contentWrite.traceId()));
+            assertThat(httpRequest.traceId(), is(greetName.traceId()));
+            assertThat(contentWrite.parentSpanId(), is(httpRequest.spanId()));
+            assertThat(greetName.parentSpanId(), is(httpRequest.spanId()));
+            assertThat(greetName.attributes(), hasEntry("example", "declarative-tracing"));
+            assertThat(greetName.attributes(), hasEntry("route", "named"));
+            assertThat(greetName.attributes(), hasEntry("userAgent", userAgent));
+        }
+    }
+
+    @Test
+    void testUpdateGreeting() {
+        var response = client.post("/hello")
+                .contentType(MediaTypes.TEXT_PLAIN)
+                .submit("Hola");
+
+        assertThat(response.status(), is(Status.NO_CONTENT_204));
+        response.close();
+
+        try {
+            var entity = client.get("/hello")
+                    .accept(MediaTypes.TEXT_PLAIN)
+                    .requestEntity(String.class);
+            assertThat(entity, is("Hola World"));
+        } finally {
+            client.post("/hello")
+                    .contentType(MediaTypes.TEXT_PLAIN)
+                    .submit("Hello")
+                    .close();
+        }
+    }
+
+    private static List<JsonLogConverter.LogSpan> spans(List<JsonLogConverter.LogResourceScopeSpans> resourceSpans) {
+        List<JsonLogConverter.LogSpan> result = new ArrayList<>();
+        for (JsonLogConverter.LogResourceScopeSpans resourceSpan : resourceSpans) {
+            assertThat(resourceSpan.resource().attributes(),
+                       hasEntry("service.name", "helidon-examples-declarative-tracing"));
+            for (JsonLogConverter.LogScopeSpans scopeSpans : resourceSpan.scopeSpans()) {
+                result.addAll(scopeSpans.logSpans().stream()
+                                      .map(JsonLogConverter.LogSpan.class::cast)
+                                      .toList());
+            }
+        }
+        return result;
+    }
+}

--- a/examples/declarative/tracing/src/test/resources/application-test.yaml
+++ b/examples/declarative/tracing/src/test/resources/application-test.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+telemetry:
+  service: "helidon-examples-declarative-tracing"
+  signals:
+    tracing:
+      processors:
+        - type: simple
+      exporters:
+        - type: logging_otlp


### PR DESCRIPTION
Resolves helidon-io/helidon-examples#242

Add a new declarative tracing example under `examples/declarative` using Helidon telemetry with the Zipkin exporter, plus README run instructions and focused tracing tests.
