### PR TITLE
Avoid warnings from declarative examples (4.x)

### DIFF
--- a/examples/declarative/cors/pom.xml
+++ b/examples/declarative/cors/pom.xml
@@ -94,6 +94,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/cors/src/main/java/io/helidon/examples/declarative/cors/HelloWorldEndpoint.java
+++ b/examples/declarative/cors/src/main/java/io/helidon/examples/declarative/cors/HelloWorldEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.cors;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -38,7 +37,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/cors/src/main/resources/application.yaml
+++ b/examples/declarative/cors/src/main/resources/application.yaml
@@ -29,6 +29,3 @@ cors:
     - path-pattern: "/observe/health/*"
       allow-methods: "GET"
       allow-origins: "http://www.example.com"
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/data/pom.xml
+++ b/examples/declarative/data/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -130,6 +129,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/data/src/main/resources/application.yaml
+++ b/examples/declarative/data/src/main/resources/application.yaml
@@ -18,9 +18,6 @@ server:
   port: 8080
   host: 0.0.0.0
 
-declarative:
-  ignore-incubating: true
-
 data:
   url: "jdbc:mysql://localhost:3306/pokemons"
   sources:

--- a/examples/declarative/data/src/test/java/io/helidon/examples/declarative/data/DeclarativeDataTest.java
+++ b/examples/declarative/data/src/test/java/io/helidon/examples/declarative/data/DeclarativeDataTest.java
@@ -21,10 +21,11 @@ import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -32,9 +33,10 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
-@Disabled("Missing a way to use the test container created port. Helidon team is working on this.")
 @Testcontainers(disabledWithoutDocker = true)
+@ExtendWith(DeclarativeDataTest.ContainerJdbcConfig.class)
 @ServerTest
 public class DeclarativeDataTest {
     private static final boolean IS_ARM = System.getProperty("os.arch", "amd64").equals("aarch64");
@@ -47,17 +49,12 @@ public class DeclarativeDataTest {
                     .asCompatibleSubstituteFor("mysql");
 
     @SuppressWarnings("resource")
+    @Container
     static final MySQLContainer<?> CONTAINER = new MySQLContainer<>(IS_ARM ? ARM_IMAGE : X86_IMAGE)
             .withUsername("user")
-            .withPassword("changeIt")
+            .withPassword("changeit")
             .withNetworkAliases("mysql")
             .withDatabaseName("db1");
-
-    static {
-        CONTAINER.start();
-        // override configuration value to use the container's port
-        System.setProperty("data.url", CONTAINER.getJdbcUrl());
-    }
 
     private final Http1Client client;
 
@@ -65,52 +62,48 @@ public class DeclarativeDataTest {
         this.client = client;
     }
 
-    @AfterAll
-    static void stopContainer() {
-        CONTAINER.stop();
-    }
-
     @Test
-    void testHelloWorld() {
-        var response = client.get("/hello")
-                .accept(MediaTypes.TEXT_PLAIN)
+    void testListPokemon() {
+        var response = client.get("/pokemon/all")
+                .accept(MediaTypes.APPLICATION_JSON)
                 .request(String.class);
 
         assertThat(response.status(), is(Status.OK_200));
-        String entity = response.entity();
-        assertThat(entity, is("Hello World"));
+        assertThat(response.entity(), containsString("\"name\":\"Pikachu\""));
     }
 
     @Test
-    void testHelloNamed() {
-        var response = client.get("/hello/Test")
-                .accept(MediaTypes.TEXT_PLAIN)
+    void testFindPokemon() {
+        var response = client.get("/pokemon/get/Pikachu")
+                .accept(MediaTypes.APPLICATION_JSON)
                 .request(String.class);
 
         assertThat(response.status(), is(Status.OK_200));
-        String entity = response.entity();
-        assertThat(entity, is("Hello Test"));
+        assertThat(response.entity(), containsString("\"type\":\"Electric\""));
     }
 
     @Test
-    void testUpdateGreeting() {
-        var response = client.post("/hello")
-                .contentType(MediaTypes.TEXT_PLAIN)
-                .submit("Hola");
+    void testListPokemonByType() {
+        var response = client.get("/pokemon/type/Electric")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(String.class);
 
-        assertThat(response.status(), is(Status.NO_CONTENT_204));
-        response.close();
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), containsString("\"name\":\"Raichu\""));
+    }
 
-        try {
-            var entity = client.get("/hello")
-                    .accept(MediaTypes.TEXT_PLAIN)
-                    .requestEntity(String.class);
-            assertThat(entity, is("Hola World"));
-        } finally {
-            client.post("/hello")
-                    .contentType(MediaTypes.TEXT_PLAIN)
-                    .submit("Hello")
-                    .close();
+    static final class ContainerJdbcConfig implements BeforeAllCallback, AfterAllCallback {
+        @Override
+        public void beforeAll(ExtensionContext context) {
+            var jdbcUrl = CONTAINER.getJdbcUrl();
+            System.setProperty("data.url", jdbcUrl);
+            System.setProperty("data.sources.sql.0.provider.hikari.url", jdbcUrl);
+        }
+
+        @Override
+        public void afterAll(ExtensionContext context) {
+            System.clearProperty("data.url");
+            System.clearProperty("data.sources.sql.0.provider.hikari.url");
         }
     }
 }

--- a/examples/declarative/fault-tolerance/pom.xml
+++ b/examples/declarative/fault-tolerance/pom.xml
@@ -90,6 +90,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/fault-tolerance/src/main/resources/application.yaml
+++ b/examples/declarative/fault-tolerance/src/main/resources/application.yaml
@@ -17,6 +17,3 @@
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/health/pom.xml
+++ b/examples/declarative/health/pom.xml
@@ -94,6 +94,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/health/src/main/java/io/helidon/examples/declarative/health/HelloWorldEndpoint.java
+++ b/examples/declarative/health/src/main/java/io/helidon/examples/declarative/health/HelloWorldEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.health;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -34,7 +33,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/health/src/main/resources/application.yaml
+++ b/examples/declarative/health/src/main/resources/application.yaml
@@ -29,7 +29,3 @@ server:
       observers:
         health:
           details: true
-
-# Ignore this feature's warning
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/metrics/pom.xml
+++ b/examples/declarative/metrics/pom.xml
@@ -98,6 +98,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/metrics/src/main/resources/application.yaml
+++ b/examples/declarative/metrics/src/main/resources/application.yaml
@@ -17,6 +17,3 @@
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/scheduling/pom.xml
+++ b/examples/declarative/scheduling/pom.xml
@@ -86,6 +86,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/scheduling/src/main/resources/application.yaml
+++ b/examples/declarative/scheduling/src/main/resources/application.yaml
@@ -18,6 +18,3 @@ app:
   scheduling:
     refresh-task:
       expression: "0/2 * * * * ?"
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/security/pom.xml
+++ b/examples/declarative/security/pom.xml
@@ -106,6 +106,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/security/src/main/java/io/helidon/examples/declarative/security/HelloWorldEndpoint.java
+++ b/examples/declarative/security/src/main/java/io/helidon/examples/declarative/security/HelloWorldEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.security;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -36,7 +35,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/security/src/main/resources/application.yaml
+++ b/examples/declarative/security/src/main/resources/application.yaml
@@ -36,7 +36,3 @@ security:
           - login: "jack"
             password: "changeit"
             roles: ["user"]
-
-# Ignore this feature's warning
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/tracing/README.md
+++ b/examples/declarative/tracing/README.md
@@ -96,7 +96,7 @@ Hola Jose
 
 The trace should include:
 
-* the incoming `GET` or `POST` span created by WebServer tracing,
+* the incoming `HTTP Request` span created by WebServer tracing,
 * the `content-write` span for the response, and
 * the declarative method span such as `greet-world` or `greet-name`.
 

--- a/examples/declarative/tracing/pom.xml
+++ b/examples/declarative/tracing/pom.xml
@@ -66,10 +66,6 @@
             <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.webserver.observe</groupId>
-            <artifactId>helidon-webserver-observe-telemetry-tracing</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <scope>runtime</scope>
@@ -121,6 +117,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
+++ b/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
@@ -18,8 +18,6 @@ package io.helidon.examples.declarative.tracing;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -29,7 +27,6 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.Tracing;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING)
 @RestServer.Endpoint
 @Http.Path("/hello")
 @Service.Singleton
@@ -38,7 +35,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Hello") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Hello}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/tracing/src/main/resources/application.yaml
+++ b/examples/declarative/tracing/src/main/resources/application.yaml
@@ -18,9 +18,6 @@ server:
   port: 8080
   host: 0.0.0.0
 
-declarative:
-  ignore-incubating: true
-
 app:
   greeting: "Hello"
 

--- a/examples/declarative/tracing/src/test/java/io/helidon/examples/declarative/tracing/DeclarativeTracingTest.java
+++ b/examples/declarative/tracing/src/test/java/io/helidon/examples/declarative/tracing/DeclarativeTracingTest.java
@@ -61,7 +61,7 @@ class DeclarativeTracingTest {
             Map<String, JsonLogConverter.LogSpan> spansByName = spans.stream()
                     .collect(Collectors.toMap(JsonLogConverter.LogSpan::name, span -> span));
 
-            JsonLogConverter.LogSpan httpRequest = spansByName.get("GET");
+            JsonLogConverter.LogSpan httpRequest = spansByName.get("HTTP Request");
             JsonLogConverter.LogSpan contentWrite = spansByName.get("content-write");
             JsonLogConverter.LogSpan greetName = spansByName.get("greet-name");
 

--- a/examples/declarative/validation/pom.xml
+++ b/examples/declarative/validation/pom.xml
@@ -100,6 +100,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/validation/src/main/resources/application.yaml
+++ b/examples/declarative/validation/src/main/resources/application.yaml
@@ -21,6 +21,3 @@ server:
     # THIS MUST NOT BE USED IN PRODUCTION!
     # exception message will be sent back over the network - this may give potential attackers information about your application
     include-entity: true
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webclient/README.md
+++ b/examples/declarative/webclient/README.md
@@ -24,8 +24,6 @@ Expected output should be similar to the following:
 2026.03.02 17:23:05.365 INFO Logging at runtime configured using classpath: /logging.properties
 2026.03.02 17:23:05.589 INFO [0x6217ea6a] http://0.0.0.0:8080 bound for socket '@default'
 2026.03.02 17:23:05.589 INFO Helidon SE 4.4.0-SNAPSHOT features: [Config, Encoding, JSON, Media, Registry, WebClient, WebServer]
-2026.03.02 17:23:05.589 WARNING You are using incubating features. These APIs are not production ready!
-2026.03.02 17:23:05.590 INFO    Incubating feature: JSON Binding (JSON/Binding)
 2026.03.02 17:23:05.592 INFO Started all channels in 5 milliseconds. 262 milliseconds since JVM startup. Java 21.0.7+8-LTS-245
 Server started on: http://localhost:8080/hello
 ^C2026.03.02 17:23:13.725 INFO Shutdown requested by JVM shutting down
@@ -33,8 +31,6 @@ Server started on: http://localhost:8080/hello
 2026.03.02 17:23:13.727 INFO Helidon WebServer stopped all channels.
 2026.03.02 17:23:13.727 INFO Shutdown finished
 ```
-
-Helidon JSON Binding is currently an incubating feature.
 
 # Declarative Typed WebClient
 

--- a/examples/declarative/webclient/pom.xml
+++ b/examples/declarative/webclient/pom.xml
@@ -98,6 +98,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/webclient/src/main/java/io/helidon/examples/declarative/webclient/HelloWorldServerEndpoint.java
+++ b/examples/declarative/webclient/src/main/java/io/helidon/examples/declarative/webclient/HelloWorldServerEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.webclient;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
 import io.helidon.http.Status;
@@ -35,7 +34,7 @@ class HelloWorldServerEndpoint implements HelloWorldApi {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldServerEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldServerEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webclient/src/main/resources/application.yaml
+++ b/examples/declarative/webclient/src/main/resources/application.yaml
@@ -22,6 +22,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webserver/hello-world-json/pom.xml
+++ b/examples/declarative/webserver/hello-world-json/pom.xml
@@ -90,6 +90,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/webserver/hello-world-json/src/main/java/io/helidon/examples/declarative/webserver/helloworld/json/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world-json/src/main/java/io/helidon/examples/declarative/webserver/helloworld/json/HelloWorldEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.webserver.helloworld.json;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -34,7 +33,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webserver/hello-world-json/src/main/resources/application.yaml
+++ b/examples/declarative/webserver/hello-world-json/src/main/resources/application.yaml
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webserver/hello-world-jsonb/pom.xml
+++ b/examples/declarative/webserver/hello-world-jsonb/pom.xml
@@ -90,6 +90,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/webserver/hello-world-jsonb/src/main/java/io/helidon/examples/declarative/webserver/helloworld/jsonb/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world-jsonb/src/main/java/io/helidon/examples/declarative/webserver/helloworld/jsonb/HelloWorldEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.webserver.helloworld.jsonb;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -34,7 +33,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webserver/hello-world-jsonb/src/main/resources/application.yaml
+++ b/examples/declarative/webserver/hello-world-jsonb/src/main/resources/application.yaml
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webserver/hello-world/pom.xml
+++ b/examples/declarative/webserver/hello-world/pom.xml
@@ -86,6 +86,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/webserver/hello-world/src/main/java/io/helidon/examples/declarative/webserver/helloworld/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world/src/main/java/io/helidon/examples/declarative/webserver/helloworld/HelloWorldEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.webserver.helloworld;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -34,7 +33,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webserver/hello-world/src/main/resources/application.yaml
+++ b/examples/declarative/webserver/hello-world/src/main/resources/application.yaml
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/websocket/pom.xml
+++ b/examples/declarative/websocket/pom.xml
@@ -99,6 +99,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-Ahelidon.api.preview=ignore</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/examples/declarative/websocket/src/main/resources/application.yaml
+++ b/examples/declarative/websocket/src/main/resources/application.yaml
@@ -23,8 +23,3 @@ server:
       classpath:
         - context: "web"
           location: "WEB"
-
-
-# Ignore this feature's warning
-declarative:
-  ignore-incubating: true


### PR DESCRIPTION
Resolves #297
Resolves #244

Updates the declarative examples so preview/incubating warnings are handled at compile time, configuration defaults use expression syntax, and the data example no longer emits SLF4J provider warnings at runtime.

Validation:
- mvn -B -f examples/declarative/pom.xml clean package
- ran each packaged declarative application and scanned runtime output for warnings
- ./etc/scripts/copyright.sh