### PR TITLE
Fix coherence examples failure when multicast disabled

### DIFF
--- a/examples/coherence/README.md
+++ b/examples/coherence/README.md
@@ -2,6 +2,14 @@
 
 Sample Helidon SE applications that uses Coherence CE as a cache for application data.
 
+The example sets Coherence WKA to `127.0.0.1` in `Main.java` and `MainTest.java`
+to force a local unicast cluster. Remove the following line from both files if
+you need Coherence to form a multicast cluster:
+
+```java
+System.setProperty("coherence.wka", "127.0.0.1");
+```
+
 ## Build and run
 
 ```shell

--- a/examples/coherence/src/main/java/io/helidon/examples/coherence/Main.java
+++ b/examples/coherence/src/main/java/io/helidon/examples/coherence/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026, Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/coherence/src/main/java/io/helidon/examples/coherence/Main.java
+++ b/examples/coherence/src/main/java/io/helidon/examples/coherence/Main.java
@@ -45,6 +45,9 @@ public class Main {
         // initialize global config from default configuration
         Config config = Config.create();
 
+        // set coherence WKA to force unicast cluster
+        // because cluster startup will fail when multicast is disabled.
+        System.setProperty("coherence.wka", "127.0.0.1");
         Coherence coherence = Coherence.clusterMember();
         coherence.startAndWait();
 

--- a/examples/coherence/src/main/java/io/helidon/examples/coherence/Main.java
+++ b/examples/coherence/src/main/java/io/helidon/examples/coherence/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/coherence/src/test/java/io/helidon/examples/coherence/MainTest.java
+++ b/examples/coherence/src/test/java/io/helidon/examples/coherence/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026, Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/coherence/src/test/java/io/helidon/examples/coherence/MainTest.java
+++ b/examples/coherence/src/test/java/io/helidon/examples/coherence/MainTest.java
@@ -38,6 +38,9 @@ public class MainTest {
 
     @SetUpRoute
     static void setUp(HttpRouting.Builder builder) {
+        // set coherence WKA to force unicast cluster
+        // because cluster startup will fail when multicast is disabled.
+        System.setProperty("coherence.wka", "127.0.0.1");
         Main.routing(builder);
     }
 

--- a/examples/coherence/src/test/java/io/helidon/examples/coherence/MainTest.java
+++ b/examples/coherence/src/test/java/io/helidon/examples/coherence/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
resolves https://github.com/helidon-io/helidon-examples/issues/299

**Description**
coherence examples fail when multicast is disabled. By default, coherence uses multicast and in OS like MacOS or OCI Linux, multicast communication is disabled. To resolve this issue, we should force coherence to use unicast (well-known-addresses)

**Fix**
Explicitly set the coherence.wka system property to force unicast with localhost.
README updated with the steps to change the code use multicast if desired.