### PR TITLE
4.x: Introduces ADBS example

### DIFF
--- a/examples/integrations/oci/adbs/README.md
+++ b/examples/integrations/oci/adbs/README.md
@@ -1,0 +1,96 @@
+# Helidon Oracle Autonomous AI Database Serverless Example
+
+This example consists of a simple command-line program that shows how Helidon can help with connecting your application
+to an Oracle Autonomous AI Database Serverless instance running in the Oracle Cloud.
+
+Normally connecting to an Oracle Autonomous AI Database Serverless instance requires a separate step [where client
+credentials are
+downloaded](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/connect-jdbc-thin-wallet.html#GUID-EBBB5D6B-118D-48BD-8D68-A3954EC92D2B)
+and stored on the filesystem. This example performs this step once in memory as part of connecting.
+
+The example consists of these parts and components:
+
+* An
+  [`oracle.jdbc.datasource.impl.OracleDataSource`](https://docs.oracle.com/en/database/oracle/oracle-database/26/jajdb/oracle/jdbc/datasource/impl/OracleDataSource.html)
+  subclass (`io.helidon.examples.integrations.oci.adbs.AdbsDataSource`) that can automatically connect to an existing
+  Oracle Autonomous AI Database Serverless instance running in the Oracle Cloud
+    * This data source is useful enough that it may become a Helidon extension in the future.
+* The [Oracle Universal Connection Pool](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjuar/index.html)
+  which can use that data source
+* A particular [meta-configuration](https://helidon.io/docs/latest/se/config/config-profiles#Profile-File) that
+  integrates Helidon's [support for the Oracle Cloud Secret Management
+  Service](https://docs.oracle.com/en-us/iaas/Content/secret-management/home.htm)
+* Helidon's [support for named `DataSource`s](https://helidon.io/docs/latest/se/data#_helidon_config) that uses the
+  Oracle Universal Connection Pool and Helidon Config
+
+## Oracle Cloud Requirements
+
+1. An Oracle Cloud
+   [tenancy](https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts-account.htm#concepttenancy) and a
+   [compartment](https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts-account.htm#conceptcompartment) in it.
+2. An Oracle Cloud [Vault](https://docs.oracle.com/en-us/iaas/Content/KeyManagement/home.htm) in the compartment.
+    1. Two [secrets](https://docs.oracle.com/en-us/iaas/Content/secret-management/home.htm) in that vault for your
+       database's username and password:
+       1. **`adbs.example.database.user`**: This secret should have the database username as its value.
+       2. **`adbs.example.database.password`**: This secret should have the database password as its value.
+3. An [Oracle Autonomous AI Database
+   Serverless](https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html) instance with [at least one
+   user in
+   it](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/manage-users-create.html#GUID-79BCDDA3-7B0B-47B5-B7A0-D9F155A6DB51).
+4. [Policies](https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts-account.htm#conceptpolicy) defined in the
+   compartment to:
+    1. permit a user to read from the database itself
+    2. permit a user to [read some of the database's metadata concerning
+       wallets](https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/connect-download-wallet.html#GUID-DED75E69-C303-409D-9128-5E10ADD47A35)
+    3. permit a user to read the vault's secrets
+5. A [`~/.oci/config` file](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm), or [other
+   authentication mechanism supported by
+   Helidon](https://helidon.io/docs/latest/se/integrations/oci#_configuring_authentication), configured appropriately to
+   connect to your tenancy.
+
+## System Properties
+
+This example is designed so that you can run it by supplying your personal Oracle Cloud-related information as system
+properties.  That way you don't have to edit `src/main/resources/application.yaml` (though you may if you wish). You'll
+need to define the following properties:
+
+1. **`compartment-ocid`**: You'll set this property to the value of your compartment's OCID. You can find its OCID in the
+   OCI console. (This is needed by the OCI Vault and Secrets Management APIs.)
+2. **`database-ocid`**: You'll set this property to the value of your Oracle Autonomous AI Database Serverless instance's
+   OCID. You can find its OCID in the OCI console.
+3. **`vault-ocid`**: You'll set this property to the value of your vault's OCID. You can find its OCID in the OCI console.
+
+See also:
+
+* `src/main/resources/meta-config.yaml`
+* `src/main/resources/application.yaml`
+* [Helidon Config documentation](https://helidon.io/docs/latest/se/config/introduction#_configuration)
+
+## Building and Running
+
+To build the example:
+
+```shell
+mvn -Dcompartment-ocid='...' \
+    -Ddatabase-ocid='...' \
+    -Dvault-ocid='...' \
+    package
+```
+
+To run the built example:
+
+```shell
+java -Dcompartment-ocid='...' \
+     -Ddatabase-ocid='...' \
+     -Dvault-ocid='...' \
+     -jar ./target/helidon-examples/integrations-oci-adbs.jar
+```
+
+The program will run. The first acquisition of a connection will take some time as the wallet is automatically
+downloaded and secrets are accessed. All subsequent connection acquisitions will be fast.
+
+If successful, the program will print the results of `SELECT`ing "`Hello, world!`" from the Oracle Autonomous AI
+Database Serverless instance running in the Oracle Cloud.
+
+If there is a failure, begin by ensuring that you have created the necessary Oracle Cloud resources, and supplied the
+proper Oracle Cloud information as detailed above, normally as `-D` system properties.

--- a/examples/integrations/oci/adbs/pom.xml
+++ b/examples/integrations/oci/adbs/pom.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>4.4.1</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.examples.integrations.oci</groupId>
+    <artifactId>helidon-examples-integrations-oci-adbs</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Helidon Examples Integrations OCI ADBS</name>
+    <description>An example showing itegration with Oracle Autonomous AI Database Serverless instances running in Oracle Cloud.</description>
+
+    <properties>
+        <compartment-ocid/>
+        <database-ocid/>
+        <io.helidon.config.meta-config>meta-config.yaml</io.helidon.config.meta-config>
+        <mainClass>io.helidon.examples.integrations.oci.adbs.Main</mainClass>
+        <vault-ocid/>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-types</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc17</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>oraclepki</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-database</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.data.sql.datasource</groupId>
+            <artifactId>helidon-data-sql-datasource-ucp</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci-secrets-config-source</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <ignoreNonCompile>true</ignoreNonCompile>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xpkginfo:always</arg>
+                    </compilerArgs>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.2</version>
+                <configuration>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>**/target/**/*.java</sourceFileExclude>
+                        <sourceFileExclude>**/*_.java</sourceFileExclude>
+                        <sourceFileExclude>**/*__*.java</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <compartment-ocid>${compartment-ocid}</compartment-ocid>
+                        <database-ocid>${database-ocid}</database-ocid>
+                        <io.helidon.config.meta-config>${io.helidon.config.meta-config}</io.helidon.config.meta-config>
+                        <vault-ocid>${vault-ocid}</vault-ocid>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/AdbsDataSource.java
+++ b/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/AdbsDataSource.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.adbs;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.security.UnrecoverableKeyException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import io.helidon.service.registry.Services;
+
+import com.oracle.bmc.OCID;
+import com.oracle.bmc.database.Database;
+import com.oracle.bmc.database.model.GenerateAutonomousDatabaseWalletDetails;
+import com.oracle.bmc.database.requests.GenerateAutonomousDatabaseWalletRequest;
+import com.oracle.bmc.database.responses.GenerateAutonomousDatabaseWalletResponse;
+import oracle.jdbc.datasource.impl.OracleDataSource;
+import oracle.net.jdbc.nl.NLException;
+import oracle.net.jdbc.nl.NLParamParser;
+import oracle.security.pki.OraclePKIProvider;
+import oracle.security.pki.OracleWallet;
+
+import static java.nio.charset.CodingErrorAction.REPORT;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Objects.requireNonNullElse;
+
+/**
+ * An {@link OracleDataSource} that {@linkplain #getConnection() supplies physical <code>Connection</code>s} to an <a
+ * href="https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/index.html">Oracle Autonomous AI Database
+ * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>, with automatic <a
+ * href="https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/connect-download-wallet.html#GUID-DED75E69-C303-409D-9128-5E10ADD47A35">wallet
+ * management</a> built in.
+ *
+ * @see #setDatabaseOcid(String)
+ * @see #getConnection()
+ */
+public final class AdbsDataSource extends OracleDataSource {
+
+    /**
+     * The version of this class for serialization purposes.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The Oracle Autonomous AI Database Serverless OCID.
+     */
+    private String databaseOcid;
+
+    /**
+     * The preferred suffix to help identify a database service name.
+     */
+    private String databaseServiceNameSuffix;
+
+    /**
+     * Whether this {@link AdbsDataSource} has self-configured.
+     */
+    private volatile boolean configured;
+
+    /**
+     * Creates a new {@link AdbsDataSource}.
+     *
+     * <p>All {@link javax.sql.DataSource} implementations must have a {@code public}, zero-argument constructor.</p>
+     *
+     * @throws SQLException if a database error occurs
+     */
+    public AdbsDataSource() throws SQLException {
+        super();
+        this.databaseServiceNameSuffix = "_tp";
+    }
+
+    /**
+     * Returns the OCID for an Oracle Autonomous AI Database Serverless instance.
+     *
+     * @return the OCID for an Oracle Autonomous AI Database Serverless instance
+     */
+    public String getDatabaseOcid() {
+        String databaseOcid = this.databaseOcid;
+        if (databaseOcid == null) {
+            try {
+                databaseOcid = this.getURL();
+            } catch (SQLException e) {
+                // OracleDataSource tries to synthesize a URL when none has been set; this can fail; here we don't care.
+            }
+            if (databaseOcid != null) {
+                if (OCID.isValid(databaseOcid)) {
+                    this.databaseOcid = databaseOcid;
+                } else {
+                    databaseOcid = null;
+                }
+            }
+        }
+        return databaseOcid;
+    }
+
+    /**
+     * Sets the OCID for an Oracle Autonomous AI Database Serverless instance.
+     *
+     * <p>All {@link javax.sql.DataSource} implementations must expose their configurable properties as Java Beans-style
+     * properties. Ordinarily, this method should be called exactly once during configuration and/or setup.</p>
+     *
+     * @param databaseOcid the OCID for an Oracle Autonomous AI Database Serverless instance
+     * @throws IllegalArgumentException if {@code databaseOcid} is non-{@code null} and not a {@linkplain
+     * OCID#isValid(String) valid OCID}
+     * @see OCID#isValid(String)
+     */
+    public void setDatabaseOcid(String databaseOcid) {
+        if (databaseOcid != null && !OCID.isValid(databaseOcid)) {
+            throw new IllegalArgumentException("databaseOcid: " + databaseOcid);
+        }
+        this.databaseOcid = databaseOcid;
+    }
+
+    /**
+     * Returns the preferred suffix to help identify a database service name.
+     *
+     * @return the preferred suffix to help identify a database service name; never {@code null}
+     */
+    public String getDatabaseServiceNameSuffix() {
+        return this.databaseServiceNameSuffix;
+    }
+
+    /**
+     * Sets the preferred suffix to help identify a database service name.
+     *
+     * @param suffix the suffix; normally begins with {@code _}; must be, case insensitively, <a
+     * href="https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/predefined-database-services-names.html">one
+     * of the suffixes defined by the Oracle Autonomous Database Service</a>; if {@code null}, then {@code _tp} will be used
+     */
+    public void setDatabaseServiceNameSuffix(String suffix) {
+        this.databaseServiceNameSuffix = requireNonNullElse(suffix, "_tp");
+    }
+
+    @Override // OracleDataSource
+    public Connection getConnection() throws SQLException {
+        this.ensureConfigured();
+        return super.getConnection();
+    }
+
+    @Override // OracleDataSource
+    public Connection getConnection(String username, String password) throws SQLException {
+        this.ensureConfigured();
+        return super.getConnection(username, password);
+    }
+
+    private void ensureConfigured() throws SQLException {
+        if (!this.configured) {
+            String databaseOcid = this.getDatabaseOcid();
+            if (databaseOcid != null) {
+                try {
+                    this.install(databaseOcid, this.getDatabaseServiceNameSuffix());
+                } catch (IOException
+                         | KeyManagementException
+                         | KeyStoreException
+                         | NoSuchAlgorithmException
+                         | NLException
+                         | UnrecoverableKeyException e) {
+                    throw new SQLException(e);
+                }
+            }
+            this.configured = true;
+        }
+    }
+
+    private void install(String ocid, String databaseServiceNameSuffix)
+        throws IOException,
+               KeyManagementException,
+               KeyStoreException,
+               NoSuchAlgorithmException,
+               NLException,
+               SQLException,
+               UnrecoverableKeyException {
+        this.install(this.wallet(ocid), databaseServiceNameSuffix);
+    }
+
+    private void install(GenerateAutonomousDatabaseWalletResponse response, String databaseServiceNameSuffix)
+        throws IOException,
+               KeyManagementException,
+               KeyStoreException,
+               NoSuchAlgorithmException,
+               NLException,
+               SQLException,
+               UnrecoverableKeyException {
+        if (response.getContentLength() <= 0) {
+            return;
+        }
+        if (Security.getProvider("OraclePKI") == null) {
+            // This provider can read cwallet.sso.
+            Security.addProvider(new OraclePKIProvider());
+        }
+        String url = null;
+        SSLContext sslContext = null;
+        try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(response.getInputStream()))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                try {
+                    switch (entry.getName()) {
+                        // See
+                        // https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/connect-download-wallet.html#d46713e336
+                    case "cwallet.sso":
+                        sslContext = this.sslContext(zis.readAllBytes());
+                        break;
+                    case "tnsnames.ora":
+                        // See
+                        // https://docs.oracle.com/en/database/oracle/oracle-database/26/netrf/syntax-rules-configuration-files.html
+                        url = this.url(zis.readAllBytes(), databaseServiceNameSuffix, this::setTNSEntryName);
+                        break;
+                    default:
+                        break;
+                    }
+                } finally {
+                    zis.closeEntry();
+                }
+            }
+        }
+        this.install(url, sslContext);
+    }
+
+    private void install(String url, SSLContext sslContext) throws SQLException {
+        this.setURL(url);
+        this.setSSLContext(sslContext);
+    }
+
+    private SSLContext sslContext(byte[] cwalletSsoBytes)
+        throws IOException, KeyManagementException, KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        OracleWallet wallet = new OracleWallet();
+        wallet.setWalletArray(cwalletSsoBytes, null); // null == deliberately no password
+        return sslContext(wallet.getKeyStore());
+    }
+
+    private String url(byte[] tnsnamesOraBytes,
+                       String databaseServiceNameSuffix,
+                       Consumer<? super String> tnsNameConsumer) throws IOException, NLException {
+        try (Reader tnsnamesOraReader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(tnsnamesOraBytes),
+                                                                                 US_ASCII.newDecoder()
+                                                                                 .onMalformedInput(REPORT)
+                                                                                 .onUnmappableCharacter(REPORT)))) {
+            return this.url(tnsnamesOraReader, databaseServiceNameSuffix, tnsNameConsumer);
+        }
+    }
+
+    private String url(Reader tnsnamesOraReader,
+                       String databaseServiceNameSuffix,
+                       Consumer<? super String> tnsNameConsumer) throws IOException, NLException {
+        return this.url(new NLParamParser(tnsnamesOraReader), databaseServiceNameSuffix, tnsNameConsumer);
+    }
+
+    private String url(NLParamParser tnsnamesOraParser,
+                       String databaseServiceNameSuffix,
+                       Consumer<? super String> tnsNameConsumer) throws NLException {
+        int suffixLength = databaseServiceNameSuffix.length();
+        // See https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/predefined-database-services-names.html
+        for (String databaseServiceName : tnsnamesOraParser.getNLPAllNames()) {
+            // The parser happens to uppercase everything. So we need to do case-insensitive matching.
+            //
+            // If "myDATABasE_MEDiUM" ends (case-insensitively) with "_mediUm"...
+            if (databaseServiceName.regionMatches(true,
+                                                  databaseServiceName.length() - suffixLength,
+                                                  databaseServiceNameSuffix,
+                                                  0,
+                                                  suffixLength)) {
+                tnsNameConsumer.accept(databaseServiceName);
+                return "jdbc:oracle:thin:@" + tnsnamesOraParser.getNLPListElement(databaseServiceName).valueToString();
+            }
+        }
+        return null;
+    }
+
+    private GenerateAutonomousDatabaseWalletResponse wallet(String ocid) {
+        return this.wallet(Services.get(Database.class), ocid);
+    }
+
+    private GenerateAutonomousDatabaseWalletResponse wallet(Database database, String databaseOcid) {
+        return database
+            .generateAutonomousDatabaseWallet(GenerateAutonomousDatabaseWalletRequest.builder()
+                                              .autonomousDatabaseId(databaseOcid)
+                                              .generateAutonomousDatabaseWalletDetails(this.walletDetails(databaseOcid)) // <1>
+                                              .build());
+        // <1>: You need a wallet password to generate the wallet, even though you don't need one to read it for this
+        // use case. So we re-use the database OCID for this.
+    }
+
+    private GenerateAutonomousDatabaseWalletDetails walletDetails(String walletPassword) {
+        return GenerateAutonomousDatabaseWalletDetails.builder()
+            .password(walletPassword)
+            .build();
+    }
+
+    private static SSLContext sslContext(KeyStore keyStore)
+        throws KeyManagementException, KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        // The default algorithm will be "PKIX"; see
+        // https://docs.oracle.com/en/java/javase/26/docs/specs/security/standard-names.html#trustmanagerfactory-algorithms
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(keyStore);
+        // The default algorithm will be "PKIX"; see
+        // https://docs.oracle.com/en/java/javase/26/docs/specs/security/standard-names.html#keymanagerfactory-algorithms
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore,
+                               null); // deliberately no password for this KeyManagerFactory
+        // See https://docs.oracle.com/en/java/javase/26/docs/specs/security/standard-names.html#sslcontext-algorithms.
+        // We don't want to use getDefault() (which also uses "TLS") because we want a distinct instance, not the shared
+        // one.
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(keyManagerFactory.getKeyManagers(),
+                        trustManagerFactory.getTrustManagers(),
+                        null); // use the default SecureRandom source
+        return sslContext;
+    }
+
+}

--- a/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/DatabaseFactory.java
+++ b/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/DatabaseFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.adbs;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service.Inject;
+import io.helidon.service.registry.Service.Singleton;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.database.Database;
+
+import static java.util.Objects.requireNonNull;
+
+import static com.oracle.bmc.database.DatabaseClient.builder;
+
+@Singleton
+final class DatabaseFactory implements Supplier<Database> {
+
+    private final BasicAuthenticationDetailsProvider adp;
+
+    @Inject
+    DatabaseFactory(BasicAuthenticationDetailsProvider adp) {
+        super();
+        this.adp = requireNonNull(adp, "adp");
+    }
+
+    @Override // Supplier<Database>
+    public Database get() {
+        return builder().build(this.adp);
+    }
+
+}

--- a/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/Main.java
+++ b/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/Main.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.adbs;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.Services;
+
+/**
+ * This example's main class demonstrating Helidon's ability to access an <a
+ * href="https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html">Oracle Autonomous AI Database
+ * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>.
+ *
+ * @see #main(String[])
+ * @see AdbsDataSource
+ */
+public final class Main {
+
+    private Main() {
+        super();
+    }
+
+    /**
+     * Runs this example.
+     *
+     * <p>This example connects to an Oracle Autonomous AI Database Serverless instance running in Oracle Cloud that you
+     * must have provisioned beforehand (see {@code README.md} in the top-level directory of this example for more
+     * details concerning Oracle Cloud requirements).</p>
+     *
+     * @param args command line arguments; ignored by this example
+     * @throws SQLException if an error occurs
+     * @see AdbsDataSource
+     */
+    public static void main(String[] args) throws SQLException {
+        // For this example, tell Helidon to set up logging. See ../../../../../../../resources/logging.properties.
+        LogConfig.configureRuntime();
+
+        // Get the DataSource provided by Helidon Data. The DataSource will be an instance of
+        // oracle.ucp.jdbc.PoolDataSource, which is a class providing connection pooling supplied by the Oracle
+        // Universal Connection Pool, because this example's configuration specifies use of the UCP.
+        //
+        // Its underlying "connection factory", i.e. the DataSource that actually supplies physical connections, will be
+        // an instance of io.helidon.examples.integrations.oci.adbs.AdbsDataSource. This is also specified in the
+        // configuration. See ../../../../../../../resources/application.yaml. See ./AdbsDataSource.java.
+        var ds = Services.get(DataSource.class);
+
+        // Use the DataSource to connect to the database. Note that wallet download and inspection happens
+        // automatically, and the database username and password are sourced from the vault. See
+        // ../../../../../../../resources/meta-config.yaml and ../../../../../../../resources/application.yaml.
+        //
+        // This first connection acquisition will take some time as the wallet is downloaded and secrets are read. You
+        // can see what is happening by adjusting the log levels in ../../../../../../../resources/logging.properties
+        // and re-building the program.
+        try (var c = ds.getConnection();
+             var s = c.createStatement();
+             var rs = s.executeQuery("SELECT 'Hello, ';")) {
+            while (rs.next()) {
+                System.out.print(rs.getString(1));
+            }
+        }
+
+        // This next connection acquisition will be very fast because all the other work has been done already.
+        try (var c = ds.getConnection();
+             var s = c.createStatement();
+             var rs = s.executeQuery("SELECT 'world!';")) {
+            while (rs.next()) {
+                System.out.println(rs.getString(1));
+            }
+        }
+    }
+
+}

--- a/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/package-info.java
+++ b/examples/integrations/oci/adbs/src/main/java/io/helidon/examples/integrations/oci/adbs/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes and interfaces related to demonstrating Helidon's ability to access an <a
+ * href="https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html">Oracle Autonomous AI Database
+ * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>.
+ *
+ * @see io.helidon.examples.integrations.oci.adbs.Main
+ * @see io.helidon.examples.integrations.oci.adbs.AdbsDataSource
+ */
+package io.helidon.examples.integrations.oci.adbs;

--- a/examples/integrations/oci/adbs/src/main/resources/application.yaml
+++ b/examples/integrations/oci/adbs/src/main/resources/application.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+data:
+  sources:
+    sql:
+      - name: "example"
+        provider:
+          ucp:
+
+            # This configuration is for Helidon Data's named data source support. For more, see
+            # https://helidon.io/docs/latest/se/data#_helidon_config. In this YAML subsection, we are configuring
+            # Oracle's Universal Connection Pool (UCP) by way of Helidon Data's support for it.
+
+            # The "connection factory class name": the name of a class, usually a DataSource subtype, and usually an
+            # OracleDataSource subtype, that vends physical database connections. The
+            # io.helidon.examples.integrations.oci.adbs.AdbsDataSource is an OracleDataSource that also handles wallet
+            # management transparently. See
+            # https://docs.oracle.com/en/database/oracle/oracle-database/26/jjuar/oracle/ucp/jdbc/PoolDataSource.html#setConnectionFactoryClassName(java.lang.String)
+            connection-factory-class-name: "io.helidon.examples.integrations.oci.adbs.AdbsDataSource"
+
+            # Needed for this example because downloading the wallet the first time can be slow. See
+            # https://docs.oracle.com/en/database/oracle/oracle-database/26/jjuar/oracle/ucp/jdbc/PoolDataSource.html#setCreateConnectionInBorrowThread(boolean)
+            create-connection-in-borrow-thread: true
+
+            # If the URL is a valid Oracle Autonomous AI Database Serverless OCID, and the connection-factory-class-name
+            # is set to io.helidon.examples.integrations.oci.adbs.AdbsDataSource (as it is above), then connectivity
+            # to the database, including mTLS with an Oracle wallet, will happen automatically.
+            url: "${database-ocid}"
+
+            # Here we set the username and password properties to Helidon Config configuration substitutions. The
+            # referenced keys should be Secret Management Service secret names.
+            # See also: ./meta-config.yaml.
+            username: "${adbs.example.database.user}"
+            password: "${adbs.example.database.password}"

--- a/examples/integrations/oci/adbs/src/main/resources/logging.properties
+++ b/examples/integrations/oci/adbs/src/main/resources/logging.properties
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Quiet MetaConfigFinder's INFO output for this example
+io.helidon.config.MetaConfigFinder.level=WARNING
+
+# Quient Helidon logging configuration information for this example
+io.helidon.logging.jul.JulProvider.level=WARNING
+
+# The log level for the OCI Java SDK. Set to FINE to see lots of information.
+com.oracle.bmc.level=SEVERE

--- a/examples/integrations/oci/adbs/src/main/resources/meta-config.yaml
+++ b/examples/integrations/oci/adbs/src/main/resources/meta-config.yaml
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+sources:
+  - type: 'environment-variables'
+  - type: 'system-properties'
+  - type: 'classpath'
+    properties:
+        optional: true
+        resource: 'application.yaml'
+  - type: 'oci-secrets'
+    properties:
+        optional: true
+
+        #
+        # This YAML subsection configures Helidon's support for Oracle Cloud's Secrets Management Service ("Vault"). See
+        # https://helidon.io/docs/v4/apidocs/io.helidon.integrations.oci.secrets.configsource/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.html
+        # for more information.
+        #
+        # For more on meta-configuration in general, see https://helidon.io/docs/latest/se/config/config-profiles. This
+        # file, meta-config.yaml, is default meta-configuration.
+        #
+
+        # Only relevant when lazy is true; this regular expression governs what properties will be sought lazily in a
+        # vault. Ignored otherwise. Commented out here, since lazy is false by default.
+        # accept-pattern: '^adbs\.example\..*$'
+
+        # Usually false. When false, vault secrets are loaded once, eagerly. When true, you should define an
+        # accept-pattern (see above).
+        lazy: false
+
+        # The compartment OCID housing a vault.
+        compartment-ocid: "${compartment-ocid}"
+
+        # A Vault OCID.
+        vault-ocid: "${vault-ocid}"

--- a/examples/integrations/oci/adbs/src/test/java/io/helidon/examples/integrations/oci/adbs/ConnectivityTest.java
+++ b/examples/integrations/oci/adbs/src/test/java/io/helidon/examples/integrations/oci/adbs/ConnectivityTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.adbs;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import io.helidon.config.Config;
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * A JUnit Jupiter test suite that exercises the {@link AdbsDataSource} class.
+ *
+ * <p>For user convenience and example simplicitly, tests in this suite use JUnit "assumptions", which allow for tests
+ * to be simply skipped if required information is missing. For the required information, see the {@code README.md} file
+ * in the top-level directory of this example. For more information about JUnit assumptions, ee {@link
+ * org.junit.jupiter.api.Assumptions}.</p>
+ *
+ * @see #testConnectivity()
+ * @see org.junit.jupiter.api.Assumptions
+ */
+final class ConnectivityTest {
+
+    private ConnectivityTest() {
+        super();
+    }
+
+    /**
+     * Tests the {@link AdbsDataSource} class to ensure that it can connect to an Oracle Autonomous AI Database
+     * Serverless instance running in the Oracle Cloud, complete with automatic wallet download and <a
+     * href="https://docs.oracle.com/en-us/iaas/Content/secret-management/home.htm">Secret Management Service</a>
+     * integration.
+     *
+     * @exception SQLException if a database error occurs
+     */
+    @Test
+    void testConnectivity() throws SQLException {
+        Config config = Services.get(Config.class);
+
+        // For user experience and example simplicity, this unit test uses JUnit "assumptions" to make sure this test is
+        // simply skipped if required configuration is not present (rather than failing). See
+        // ../../../../../../../../../README.md for more about the required configuration. See
+        // https://docs.junit.org/5.12.2/api/org.junit.jupiter.api/org/junit/jupiter/api/Assumptions.html for more about
+        // JUnit assumptions.
+
+        // Make sure the compartment-ocid property was set, usually as a System property.
+        String compartmentOcid = config.get("compartment-ocid").asString().orElse(null);
+        assumeTrue(compartmentOcid != null && !compartmentOcid.isBlank());
+
+        // Make sure the database-ocid property was set, usually as a System property.
+        String databaseOcid = config.get("database-ocid").asString().orElse(null);
+        assumeTrue(databaseOcid != null && !databaseOcid.isBlank());
+
+        // Make sure the vault-ocid property was set, usually as a System property.
+        String vaultOcid = config.get("vault-ocid").asString().orElse(null);
+        assumeTrue(vaultOcid != null && !vaultOcid.isBlank());
+
+        // If the assumptions above passed, continue to run the test. Otherwise execution will effectively stop here.
+
+        // Create a new AdbsDataSource that supplies physical connections to an Oracle Autonomous AI Database Serverless
+        // instance running in the Oracle Cloud.
+        AdbsDataSource ds = new AdbsDataSource();
+
+        // Set its URL to the database OCID. If the URL is an OCID, then the special features of AdbsDataSource are
+        // enabled. If it is not an OCID, then they are not, and the AdbsDataSource behaves just like the ordinary
+        // oracle.jdbc.datasource.impl.OracleDataSource it extends
+        // (https://docs.oracle.com/en/database/oracle/oracle-database/26/jajdb/oracle/jdbc/datasource/impl/OracleDataSource.html).
+        //
+        // See
+        // ../../../../../../../../main/java/io/helidon/examples/integrations/oci/adbs/AdbsDataSource.java.
+        ds.setURL(databaseOcid);
+
+        // Ask Helidon Config for the value of the adbs.example.database.user and adbs.example.database.password
+        // properties. Because Helidon's support for the Oracle Cloud's Secrets Management API is referenced in this
+        // example, the Secrets Management API ("the vault") will be consulted for these properties. See
+        // ../../../../../../../../main/resources/application.yaml and
+        // ../../../../../../../../main/resources/meta-config.yaml.
+        ds.setUser(config.get("adbs.example.database.user").asString().orElseThrow(AssertionError::new));
+        ds.setPassword(config.get("adbs.example.database.password").asString().orElseThrow(AssertionError::new));
+
+        // Connect to the database and prove the AdbsDataSource works properly.
+        try (var c = ds.getConnection();
+             var s = c.createStatement();
+             var rs = s.executeQuery("SELECT 'Hello, world!';")) {
+            assertThat(rs.next(), is(true));
+            assertThat(rs.getString(1), is("Hello, world!"));
+            assertThat(rs.next(), is(false));
+        }
+
+        // (Once the AdbsDataSource successfully connects, it will store the TNS entry name it found and used.)
+        assertThat(ds.getTNSEntryName(), not(nullValue()));
+
+    }
+
+}

--- a/examples/integrations/oci/pom.xml
+++ b/examples/integrations/oci/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
     <description>Examples of integration with OCI (Oracle Cloud).</description>
 
     <modules>
+        <module>adbs</module>
         <module>atp</module>
         <module>atp-cdi</module>
         <module>genai</module>


### PR DESCRIPTION
This pull request introduces an example showing integration with [Oracle Autonomous AI Database Serverless](https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html) (ADBS).

It is modeled loosely after the existing ATP example, which it should probably eventually replace.

Its `README.md` tries to give enough information to get started, but is deliberately not a tutorial on how to provision things in the Oracle Cloud.