### PR TITLE
Introduces adbs-iam example

### DIFF
--- a/examples/integrations/oci/adbs-iam/README.md
+++ b/examples/integrations/oci/adbs-iam/README.md
@@ -1,0 +1,84 @@
+# Helidon Oracle Autonomous AI Database Serverless Example Using Token-Based Authentication
+
+This example consists of a simple command-line program that shows how Helidon can help with connecting your application
+to an Oracle Autonomous AI Database Serverless instance running in the Oracle Cloud using IAM authentication by using
+official, open-source [Oracle OJDBC
+extensions](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#oracle-jdbc-providers-for-oci).
+
+The example consists of these parts and components:
+
+* A main class that exercises the example.
+* Helidon's [support for named `DataSource`s](https://helidon.io/docs/latest/se/data#_helidon_config) that uses the
+  Oracle Universal Connection Pool and Helidon Config
+* A `src/main/resources/application.yaml` file that configures the example.
+* Usage, via configuration, of the [Oracle Universal Connection
+  Pool](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjuar/index.html).
+* Usage, via configuration, of the [Oracle OJDBC OCI
+  Provider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#oracle-jdbc-providers-for-oci)
+  project. From that project:
+    * Usage, via configuration, of the [Access Token
+      {rovider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#access-token-provider)
+    * Usage, via configuration, of the [Database Connection String
+      Provider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#database-connection-string-provider)
+
+## Oracle Cloud Requirements
+
+1. An Oracle Cloud
+   [tenancy](https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts-account.htm#concepttenancy) and a
+   [compartment](https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts-account.htm#conceptcompartment) in it.
+3. An [Oracle Autonomous AI Database
+   Serverless](https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html) instance with [at least one
+   user in
+   it](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/manage-users-create.html#GUID-79BCDDA3-7B0B-47B5-B7A0-D9F155A6DB51).
+    1. The database must be configured to [allow walletless TLS connections](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/autonomous-provision.html)
+    2. The database must be configured to allow [IAM authentication](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/iam-access-database.html#GUID-CFC74EAF-E887-4B1F-9E9A-C956BCA0BEA9)
+4. [Policies](https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts-account.htm#conceptpolicy) defined in the
+   compartment to:
+    1. permit a user to `use` `autonomous-database-family` in the database's compartment
+5. A [`~/.oci/config` file](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm), or [other
+   authentication mechanism supported by the OJDBC OCI
+   Provider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-authentication-1),
+   [configured](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#common-parameters-for-resource-providers)
+   appropriately, used to connect to your tenancy.
+
+## Environment Variables
+
+This example is designed so that you can run it by supplying your personal Oracle Cloud-related information as
+environment variables. That way you don't have to edit `src/main/resources/application.yaml`, since environment
+variables have a higher precedence in this example (though you may if you wish). You'll need to define the following
+environment variables in the environment where you will run the example:
+
+1. **`COMPARTMENT_OCID`**: You'll set this variable to the value of your compartment's OCID. You can find its OCID in
+   the OCI console. (This is needed to [scope your access token
+   appropriately](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-a-scope).)
+2. **`DATABASE_OCID`**: You'll set this variable to the value of your Oracle Autonomous AI Database Serverless instance's
+   OCID. You can find its OCID in the OCI console.
+
+See also:
+
+* `src/main/resources/application.yaml`
+* [Helidon Config documentation](https://helidon.io/docs/latest/se/config/introduction#_configuration)
+
+## Building and Running
+
+To build the example:
+
+```shell
+mvn package
+```
+
+To run the built example (remember to set the required environment variables first; see above):
+
+```shell
+java -jar ./target/helidon-examples-integrations-oci-adbs-iam.jar
+```
+
+The program will run. The first acquisition of a connection will take some time as the initial connection is negotiated.
+All subsequent connection acquisitions will be fast. Access tokens are
+[cached](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#caching-mechanism) by default.
+
+If successful, the program will print the results of `SELECT`ing "`Hello, world!`" from the Oracle Autonomous AI
+Database Serverless instance running in the Oracle Cloud.
+
+If there is a failure, begin by ensuring that you have created the necessary Oracle Cloud resources, and supplied the
+proper Oracle Cloud information as detailed above.

--- a/examples/integrations/oci/adbs-iam/README.md
+++ b/examples/integrations/oci/adbs-iam/README.md
@@ -17,7 +17,7 @@ The example consists of these parts and components:
   Provider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#oracle-jdbc-providers-for-oci)
   project. From that project:
     * Usage, via configuration, of the [Access Token
-      {rovider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#access-token-provider)
+      {provider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#access-token-provider)
     * Usage, via configuration, of the [Database Connection String
       Provider](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#database-connection-string-provider)
 

--- a/examples/integrations/oci/adbs-iam/pom.xml
+++ b/examples/integrations/oci/adbs-iam/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>4.5.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.examples.integrations.oci</groupId>
+    <artifactId>helidon-examples-integrations-oci-adbs-iam</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Helidon Examples Integrations OCI ADBS IAM</name>
+    <description>An example showing IAM integration with Oracle Autonomous AI Database Serverless instances running in Oracle Cloud.</description>
+
+    <properties>
+
+        <!--
+            The main class the example's built jar file will use when run from the command line.
+        -->
+        <mainClass>io.helidon.examples.integrations.oci.adbs.iam.Main</mainClass>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.data.sql.datasource</groupId>
+            <artifactId>helidon-data-sql-datasource-ucp</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc-provider-oci</artifactId>
+            <version>1.0.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <ignoreNonCompile>true</ignoreNonCompile>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xpkginfo:always</arg>
+                    </compilerArgs>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.2</version>
+                <configuration>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>**/target/**/*.java</sourceFileExclude>
+                        <sourceFileExclude>**/*_.java</sourceFileExclude>
+                        <sourceFileExclude>**/*__*.java</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/Main.java
+++ b/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/Main.java
@@ -34,6 +34,10 @@ import static io.helidon.logging.common.LogConfig.configureRuntime;
  */
 public final class Main {
 
+    private Main() {
+        super();
+    }
+
     /**
      * Runs this example.
      *

--- a/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/Main.java
+++ b/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/Main.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.adbs.iam;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import io.helidon.service.registry.Services;
+
+import static io.helidon.logging.common.LogConfig.configureRuntime;
+
+/**
+ * This example's main class demonstrating Helidon's ability to access an <a
+ * href="https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html">Oracle Autonomous AI Database
+ * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>, using <a
+ * href="https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#access-token-provider">token-based
+ * authentication</a>.
+ *
+ * @see #main(String[])
+ */
+public final class Main {
+
+    /**
+     * Runs this example.
+     *
+     * <p>This example connects to an Oracle Autonomous AI Database Serverless instance running in Oracle Cloud that you
+     * must have provisioned and configured beforehand (see {@code README.md} in the top-level directory of this example
+     * for more details concerning Oracle Cloud requirements).</p>
+     *
+     * @param args command line arguments; ignored by this example
+     * @throws SQLException if a database error occurs
+     */
+    public static void main(String[] args) throws SQLException {
+        // For this example, tell Helidon to set up logging. See ../../../../../../../resources/logging.properties.
+        configureRuntime();
+
+        // Use the service registry to get a DataSource that has been comfigured in (in this example)
+        // ../../../../../../../../resources/application.yaml.
+        try (var c = Services.get(DataSource.class).getConnection();
+             var s = c.createStatement();
+             var rs = s.executeQuery("SELECT 'Hello, world!';");) {
+            rs.next();
+            System.out.println(rs.getString(1));
+        }
+    }
+
+}

--- a/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/package-info.java
+++ b/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes and interfaces related to demonstrating Helidon's ability to access an <a
+ * href="https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html">Oracle Autonomous AI Database
+ * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>, using {@linkplain
+ * com.oracle.bmc.identity.dataplane.Dataplane#generateScopedAccessToken(com.oracle.bmc.identitydataplane.requests.GenerateScopedAccessTokenRequest)
+ * token-based authentication}.
+ *
+ * @see io.helidon.examples.integrations.oci.adbs.iam.Main
+ */
+package io.helidon.examples.integrations.oci.adbs.iam;

--- a/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/package-info.java
+++ b/examples/integrations/oci/adbs-iam/src/main/java/io/helidon/examples/integrations/oci/adbs/iam/package-info.java
@@ -17,9 +17,9 @@
 /**
  * Contains classes and interfaces related to demonstrating Helidon's ability to access an <a
  * href="https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/index.html">Oracle Autonomous AI Database
- * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>, using {@linkplain
- * com.oracle.bmc.identity.dataplane.Dataplane#generateScopedAccessToken(com.oracle.bmc.identitydataplane.requests.GenerateScopedAccessTokenRequest)
- * token-based authentication}.
+ * Serverless</a> instance running in the <a href="https://cloud.oracle.com/">Oracle Cloud</a>, using <a
+ * href="https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#access-token-provider"> token-based
+ * authentication</a>.
  *
  * @see io.helidon.examples.integrations.oci.adbs.iam.Main
  */

--- a/examples/integrations/oci/adbs-iam/src/main/resources/application.yaml
+++ b/examples/integrations/oci/adbs-iam/src/main/resources/application.yaml
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+data:
+  sources:
+    sql:
+      - name: "example"
+        provider:
+          ucp:
+
+            # This configuration is for Helidon Data's named data source support. For more, see
+            # https://helidon.io/docs/latest/se/data#_helidon_config. In this YAML subsection, we are configuring
+            # Oracle's Universal Connection Pool (UCP) by way of Helidon Data's support for it.
+
+            # The "connection factory class name": the name of a class, usually a DataSource subtype, and almost always
+            # an oracle.jdbc.datasource.impl.OracleDataSource subtype, that vends physical database connections. See
+            # https://docs.oracle.com/en/database/oracle/oracle-database/26/jjuar/oracle/ucp/jdbc/PoolDataSource.html#setConnectionFactoryClassName(java.lang.String).
+            # This should be "oracle.jdbc.datasource.impl.OracleDataSource" in almost all cases. See
+            # https://docs.oracle.com/en/database/oracle/oracle-database/26/jajdb/oracle/jdbc/datasource/impl/OracleDataSource.html.
+            connection-factory-class-name: "oracle.jdbc.datasource.impl.OracleDataSource"
+
+            # "Connection properties" to be supplied. See
+            # https://docs.oracle.com/en/database/oracle/oracle-database/26/jjuar/oracle/ucp/jdbc/PoolDataSource.html#setConnectionProperties(java.util.Properties).
+            connection-properties:
+
+              # This connection property is defined by
+              # https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#access-token-provider.
+              #
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon.
+              "oracle.jdbc.provider.accessToken": "ojdbc-provider-oci-token"
+
+              # See https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#caching-mechanism.
+              #
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon. The configuration properties
+              # (${compartment.ocid}, ${database.ocid}) are resolved by Helidon Config.
+              "oracle.jdbc.provider.accessToken.scope": "urn:oracle:db::id::${compartment.ocid}::${database.ocid}"
+
+              # This connection property is defined by
+              # https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#database-connection-string-provider.
+              #
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon.
+              "oracle.jdbc.provider.connectionString": "ojdbc-provider-oci-database-connection-string"
+
+              # See
+              # https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#database-connection-string-provider.
+              #
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon.
+              "oracle.jdbc.provider.connectionString.consumerGroup": "MEDIUM"
+
+              # See
+              # https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#database-connection-string-provider.
+              # This connection property is set to the value of the database.ocid Helidon Config property. Because of
+              # the rules of Helidon Config, an environment variable named DATABASE_OCID will also supply the value of
+              # this configuration property. (See
+              # https://helidon.io/docs/latest/se/config/advanced-configuration#_environment_variables_config_source.)
+              #
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon.
+              "oracle.jdbc.provider.connectionString.ocid": "${database.ocid}"
+
+              # See https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#common-parameters-for-resource-providers.
+              # See also https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-authentication-1.
+              #
+              # Valid values are:
+              #
+              # * auto-detect (the default)
+              # * config-file
+              # * cloud-shell
+              # * resource-principal
+              # * instance-principal
+              # * interactive (not recommended except in development)
+              #
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon.
+              "oracle.jdbc.provider.connectionString.authenticationMethod": "auto-detect"
+
+            # See
+            # https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleDatabaseConnectionStringProviderExample.java
+            # The proper connection string is retrieved automatically, so all that needs to be specified here is
+            # "jdbc:oracle:thin:@".
+            url: "jdbc:oracle:thin:@"

--- a/examples/integrations/oci/adbs-iam/src/main/resources/application.yaml
+++ b/examples/integrations/oci/adbs-iam/src/main/resources/application.yaml
@@ -42,9 +42,12 @@ data:
               "oracle.jdbc.provider.accessToken": "ojdbc-provider-oci-token"
 
               # See https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#caching-mechanism.
+              # See https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-a-scope.
               #
-              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon. The configuration properties
-              # (${compartment.ocid}, ${database.ocid}) are resolved by Helidon Config.
+              # This property is defined by Oracle JDBC Providers for OCI, not by Helidon.
+              # The configuration properties (${compartment.ocid}, ${database.ocid}) are resolved by Helidon Config.
+              # See https://helidon.io/docs/latest/se/config/advanced-configuration#_tokens.
+              # See https://helidon.io/docs/latest/se/config/advanced-configuration#_environment_variables_config_source.
               "oracle.jdbc.provider.accessToken.scope": "urn:oracle:db::id::${compartment.ocid}::${database.ocid}"
 
               # This connection property is defined by
@@ -70,9 +73,10 @@ data:
               "oracle.jdbc.provider.connectionString.ocid": "${database.ocid}"
 
               # See https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#common-parameters-for-resource-providers.
-              # See also https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-authentication-1.
+              # See https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-authentication-1.
               #
-              # Valid values are:
+              # Valid values are the following (see
+              # https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci#configuring-authentication-1):
               #
               # * auto-detect (the default)
               # * config-file

--- a/examples/integrations/oci/adbs-iam/src/main/resources/logging.properties
+++ b/examples/integrations/oci/adbs-iam/src/main/resources/logging.properties
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Quiet MetaConfigFinder's INFO output for this example
+io.helidon.config.MetaConfigFinder.level=WARNING
+
+# Quiet Helidon logging configuration information for this example
+io.helidon.logging.jul.JulProvider.level=WARNING
+
+# The log level for the OCI Java SDK. Set to FINE to see lots of information.
+com.oracle.bmc.level=SEVERE

--- a/examples/integrations/oci/pom.xml
+++ b/examples/integrations/oci/pom.xml
@@ -35,6 +35,7 @@
 
     <modules>
         <module>adbs</module>
+        <module>adbs-iam</module>
         <module>atp</module>
         <module>atp-cdi</module>
         <module>genai</module>


### PR DESCRIPTION
This PR adds an ADBS-focused example that shows walletless connection to an Oracle Autonomous AI Database Serverless instance running in the Oracle Cloud using IAM authentication. It makes use of the official [Oracle OJDBC Providers for OCI](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-oci) project.