### PR TITLE
Fix outbound override JWT example (4.x)

### DIFF
--- a/examples/security/outbound-override/src/main/resources/client-service-jwt.yaml
+++ b/examples/security/outbound-override/src/main/resources/client-service-jwt.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,9 +34,9 @@ security:
         password: "changeit"
         roles: ["user"]
   - jwt:
+      authenticate: false
       allow-impersonation: true
       atn-token:
-        # we are not interested in inbound tokens
         verify-signature: false
       sign-token:
         jwk.resource.resource-path: "signing-jwk.json"


### PR DESCRIPTION
Backport of #309 to `dev-4.x`.

Updates the outbound override JWT example so the client-side JWT provider is explicitly outbound-only while still disabling inbound token signature verification. This keeps HTTP Basic as the inbound authenticator and avoids requiring issuer/audience configuration for the client service when signature verification is disabled.
