### PR TITLE
Update JSON-RPC example for Helidon JSON

### DIFF
--- a/examples/webserver/jsonrpc/pom.xml
+++ b/examples/webserver/jsonrpc/pom.xml
@@ -48,20 +48,12 @@
             <artifactId>helidon-webserver-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
+            <artifactId>helidon-http-media-json</artifactId>
         </dependency>
         <dependency>
             <artifactId>helidon-logging-jul</artifactId>
@@ -99,6 +91,19 @@
                         <id>copy-libs</id>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.bundles</groupId>
+                            <artifactId>helidon-bundles-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
+++ b/examples/webserver/jsonrpc/src/main/java/io/helidon/examples/webserver/jsonrpc/JsonRpcMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.examples.webserver.jsonrpc;
 
 import java.time.Duration;
 
+import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
@@ -95,6 +96,7 @@ public class JsonRpcMain {
      * @param when time to start machine
      * @param duration for how long
      */
+    @Json.Entity
     public record StartStopParams(String when, Duration duration) {
     }
 
@@ -103,6 +105,7 @@ public class JsonRpcMain {
      *
      * @param status status of operation
      */
+    @Json.Entity
     public record StartStopResult(String status) {
     }
 }

--- a/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
+++ b/examples/webserver/jsonrpc/src/test/java/io/helidon/examples/webserver/jsonrpc/JsonRpcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
-import jakarta.json.Json;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.examples.webserver.jsonrpc.JsonRpcMain.StartStopResult;
@@ -59,7 +58,7 @@ class JsonRpcTest {
                 .path("/rpc/machine")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
-            assertThat(res.rpcId(), is(Optional.of(Json.createValue(1))));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(1)));
             assertThat(res.result().isPresent(), is(true));
             StartStopResult result = res.result().get().as(StartStopResult.class);
             assertThat(result.status(), is("RUNNING"));
@@ -74,7 +73,7 @@ class JsonRpcTest {
                 .path("/rpc/machine")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
-            assertThat(res.rpcId(), is(Optional.of(Json.createValue(2))));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(2)));
             assertThat(res.result().isPresent(), is(true));
             StartStopResult result = res.result().get().as(StartStopResult.class);
             assertThat(result.status(), is("STOPPED"));


### PR DESCRIPTION
Related to helidon-io/helidon#11356
Depends on helidon-io/helidon#12041

Updates the JSON-RPC example for the Helidon JSON based JSON-RPC APIs in 27.x.

The example now uses Helidon JSON binding and Helidon JSON media support, and no longer declares the JSON-P, JSON-B, or Yasson dependencies that were needed by the previous API shape.
