### PR TITLE
Update metrics examples for new metrics APIs (27.x)

### DIFF
--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
@@ -69,10 +69,12 @@ public class GreetService implements HttpService {
         Config config = Services.get(Config.class);
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
 
-        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
-        timerForGets = meterRegistry.getOrCreate(Timer.builder(TIMER_FOR_GETS)
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        MeterRegistry meterRegistry = Services.get(MeterRegistry.class);
+        timerForGets = meterRegistry.getOrCreate(metricsFactory.timerBuilder(TIMER_FOR_GETS)
                                                          .baseUnit(Meter.BaseUnits.NANOSECONDS));
-        personalizedGreetingsCounter = meterRegistry.getOrCreate(Counter.builder(COUNTER_FOR_PERSONALIZED_GREETINGS));
+        personalizedGreetingsCounter = meterRegistry.getOrCreate(
+                metricsFactory.counterBuilder(COUNTER_FOR_PERSONALIZED_GREETINGS));
     }
 
     /**

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import io.helidon.config.Config;
 import io.helidon.http.Status;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
@@ -67,8 +68,10 @@ public class GreetService implements HttpService {
     GreetService(MeterRegistry meterRegistry) {
         Config config = Services.get(Config.class);
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
-        timerForGets = meterRegistry.getOrCreate(Timer.builder(TIMER_FOR_GETS));
-        personalizedGreetingsCounter = meterRegistry.getOrCreate(Counter.builder(COUNTER_FOR_PERSONALIZED_GREETINGS));
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        timerForGets = meterRegistry.getOrCreate(metricsFactory.timerBuilder(TIMER_FOR_GETS));
+        personalizedGreetingsCounter = meterRegistry.getOrCreate(
+                metricsFactory.counterBuilder(COUNTER_FOR_PERSONALIZED_GREETINGS));
     }
 
     /**

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -84,7 +84,7 @@ public final class Main {
                 .scoping(ScopingConfig.builder()
                                  .putScope(Meter.Scope.APPLICATION, scopeConfig));
 
-        MeterRegistry meterRegistry = MetricsFactory.getInstance(config).globalRegistry(metricsConfigBuilder.build());
+        MeterRegistry meterRegistry = Services.get(MetricsFactory.class).globalRegistry(metricsConfigBuilder.build());
 
         MetricsObserver metrics = MetricsObserver.builder()
                 .meterRegistry(meterRegistry)

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/HttpStatusMetricService.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/HttpStatusMetricService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
-import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
@@ -53,14 +53,16 @@ public class HttpStatusMetricService implements HttpService {
     }
 
     private HttpStatusMetricService() {
-        MeterRegistry registry = Metrics.globalRegistry();
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        MeterRegistry registry = Services.get(MeterRegistry.class);
 
         // Declare the counters and keep references to them.
         for (int i = 1; i < responseCounters.length; i++) {
 
-            responseCounters[i] = registry.getOrCreate(Counter.builder(STATUS_COUNTER_NAME)
-                                                               .tags(Set.of(Tag.create(STATUS_TAG_NAME, i + "xx")))
-                                                               .description(COUNTER_DESCR));
+            responseCounters[i] = registry.getOrCreate(
+                    metricsFactory.counterBuilder(STATUS_COUNTER_NAME)
+                            .tags(Set.of(metricsFactory.tagCreate(STATUS_TAG_NAME, i + "xx")))
+                            .description(COUNTER_DESCR));
         }
     }
 

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/SimpleGreetService.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/SimpleGreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
@@ -45,8 +45,9 @@ public class SimpleGreetService implements HttpService {
     private static final Logger LOGGER = Logger.getLogger(SimpleGreetService.class.getName());
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
-    private final MeterRegistry registry = Metrics.globalRegistry();
-    private final Counter accessCtr = registry.getOrCreate(Counter.builder("accessctr"));
+    private final MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+    private final MeterRegistry registry = Services.get(MeterRegistry.class);
+    private final Counter accessCtr = registry.getOrCreate(metricsFactory.counterBuilder("accessctr"));
 
     private final String greeting;
 

--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.http.Status;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
-import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServerConfig;
@@ -46,9 +45,13 @@ public class StatusTest {
 
     private final Counter[] STATUS_COUNTERS = new Counter[6];
     private final Http1Client client;
+    private final MetricsFactory metricsFactory;
+    private final MeterRegistry meterRegistry;
 
-    public StatusTest(Http1Client client) {
+    public StatusTest(Http1Client client, MetricsFactory metricsFactory, MeterRegistry meterRegistry) {
         this.client = client;
+        this.metricsFactory = metricsFactory;
+        this.meterRegistry = meterRegistry;
     }
 
     @SetUpServer
@@ -61,10 +64,10 @@ public class StatusTest {
 
     @BeforeEach
     void findStatusMetrics() {
-        MeterRegistry meterRegistry = Metrics.globalRegistry();
         for (int i = 1; i < STATUS_COUNTERS.length; i++) {
-            STATUS_COUNTERS[i] = meterRegistry.getOrCreate(Counter.builder(STATUS_COUNTER_NAME)
-                                                                    .tags(Set.of(Tag.create(STATUS_TAG_NAME, i + "xx"))));
+            STATUS_COUNTERS[i] = meterRegistry.getOrCreate(
+                    metricsFactory.counterBuilder(STATUS_COUNTER_NAME)
+                            .tags(Set.of(metricsFactory.tagCreate(STATUS_TAG_NAME, i + "xx"))));
         }
     }
 

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.http.Status;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
@@ -70,10 +70,12 @@ public class GreetService implements HttpService {
     GreetService() {
         Config config = Services.get(Config.class);
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
-        MeterRegistry meterRegistry = Metrics.globalRegistry();
-        timerForGets = meterRegistry.getOrCreate(Timer.builder(TIMER_FOR_GETS)
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        MeterRegistry meterRegistry = Services.get(MeterRegistry.class);
+        timerForGets = meterRegistry.getOrCreate(metricsFactory.timerBuilder(TIMER_FOR_GETS)
                                                          .baseUnit(Meter.BaseUnits.NANOSECONDS));
-        personalizedGreetingsCounter = meterRegistry.getOrCreate(Counter.builder(COUNTER_FOR_PERSONALIZED_GREETINGS));
+        personalizedGreetingsCounter = meterRegistry.getOrCreate(
+                metricsFactory.counterBuilder(COUNTER_FOR_PERSONALIZED_GREETINGS));
     }
 
     /**

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ClientMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ClientMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.service.registry.Services;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.metrics.WebClientMetrics;
@@ -45,7 +46,6 @@ import jakarta.json.JsonObject;
  */
 public class ClientMain {
 
-    private static final MeterRegistry METER_REGISTRY = Metrics.globalRegistry();
     private static final JsonBuilderFactory JSON_BUILDER = Json.createBuilderFactory(Map.of());
     private static final JsonObject JSON_NEW_GREETING;
 
@@ -150,7 +150,9 @@ public class ClientMain {
     static String clientMetricsExample(String url, Config config) {
         //This part here is only for verification purposes, it is not needed to be done for actual usage.
         String counterName = "example.metric.GET.localhost";
-        Counter counter = METER_REGISTRY.getOrCreate(Counter.builder(counterName));
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        MeterRegistry meterRegistry = Services.get(MeterRegistry.class);
+        Counter counter = meterRegistry.getOrCreate(metricsFactory.counterBuilder(counterName));
         System.out.println(counterName + ": " + counter.count());
 
         //Creates new metric which will count all GET requests and has format of example.metric.GET.<host-name>

--- a/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
+++ b/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpServer;
 import io.helidon.webclient.api.WebClient;
@@ -48,13 +48,15 @@ import static org.hamcrest.Matchers.is;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientMainTest {
 
-    private static final MeterRegistry METRIC_REGISTRY = Metrics.globalRegistry();
-
     private final WebServer server;
+    private final MetricsFactory metricsFactory;
+    private final MeterRegistry metricRegistry;
     private final Path testFile;
 
-    public ClientMainTest(WebServer server) {
+    public ClientMainTest(WebServer server, MetricsFactory metricsFactory, MeterRegistry metricRegistry) {
         this.server = server;
+        this.metricsFactory = metricsFactory;
+        this.metricRegistry = metricRegistry;
         server.context().register(server);
         this.testFile = Paths.get("test.txt");
     }
@@ -99,7 +101,7 @@ public class ClientMainTest {
     @Order(3)
     public void testMetricsExample() {
         String counterName = "example.metric.GET.localhost";
-        Counter counter = METRIC_REGISTRY.getOrCreate(Counter.builder(counterName));
+        Counter counter = metricRegistry.getOrCreate(metricsFactory.counterBuilder(counterName));
         assertThat("Counter " + counterName + " has not been 0", counter.count(), is(0L));
         ClientMain.clientMetricsExample("http://localhost:" + server.port() + "/greet", Config.create());
         assertThat("Counter " + counterName + " " + "has not been 1", counter.count(), is(1L));


### PR DESCRIPTION
Related to helidon-io/helidon#12075. Updates the metrics examples to use MetricsFactory and service registry access instead of deprecated static metrics APIs.