### PR TITLE
Remove interim status from metrics example test (27.x)

### DIFF
--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
@@ -73,7 +73,6 @@ public class StatusTest {
 
     @Test
     void checkStatusMetrics() throws InterruptedException {
-        checkAfterStatus(Status.create(171));
         checkAfterStatus(Status.OK_200);
         checkAfterStatus(Status.CREATED_201);
         checkAfterStatus(Status.NO_CONTENT_204);


### PR DESCRIPTION
Removes the synthetic 171 response from the HTTP status metrics example test.

HTTP/1 clients now treat informational responses as interim responses and wait for a final response, so the example should not use an informational status as a complete final response.
