### PR TITLE
Remove interim status from metrics example test (4.x)

### DIFF
--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,6 @@ public class StatusTest {
 
     @Test
     void checkStatusMetrics() throws InterruptedException {
-        checkAfterStatus(Status.create(171));
         checkAfterStatus(Status.OK_200);
         checkAfterStatus(Status.CREATED_201);
         checkAfterStatus(Status.NO_CONTENT_204);


### PR DESCRIPTION
Removes the synthetic 171 response from the HTTP status metrics example test.

HTTP/1 clients now treat informational responses as interim responses and wait for a final response, so the example should not use an informational status as a complete final response.
