### PR TITLE
Use a custom registry in metrics filtering example (27.x)

### DIFF
--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -77,18 +77,20 @@ public final class Main {
                 .exclude(Pattern.compile(GreetService.TIMER_FOR_GETS))
                 .build();
 
-        MetricsConfig initialMetricsConfig = config.get(MetricsConfig.METRICS_CONFIG_KEY)
-                .as(MetricsConfig::create)
-                .orElseGet(MetricsConfig::create);
-        MetricsConfig.Builder metricsConfigBuilder = MetricsConfig.builder(initialMetricsConfig)
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        // This global registry initialization can be removed once custom registries own their publishers.
+        Services.get(MeterRegistry.class);
+        MetricsConfig metricsConfig = MetricsConfig.builder(metricsFactory.metricsConfig())
                 .scoping(ScopingConfig.builder()
-                                 .putScope(Meter.Scope.APPLICATION, scopeConfig));
+                                 .putScope(Meter.Scope.APPLICATION, scopeConfig))
+                .warnOnMultipleRegistries(false)
+                .build();
 
-        MeterRegistry meterRegistry = Services.get(MetricsFactory.class).globalRegistry(metricsConfigBuilder.build());
+        MeterRegistry meterRegistry = metricsFactory.createMeterRegistry(metricsConfig);
 
         MetricsObserver metrics = MetricsObserver.builder()
                 .meterRegistry(meterRegistry)
-                .metricsConfig(metricsConfigBuilder)
+                .metricsConfig(metricsConfig)
                 .build();
 
         server.featuresDiscoverServices(false)


### PR DESCRIPTION
Related to helidon-io/helidon#12075.

Update the metrics filtering example to create a non-global meter registry for its custom scoping configuration. The temporary global-registry initialization keeps the example compatible until the corresponding core changes are available.
