### PR TITLE
Update examples for unscoped metrics (27.x)

### DIFF
--- a/examples/dbclient/metrics/README.md
+++ b/examples/dbclient/metrics/README.md
@@ -31,5 +31,5 @@ curl -X PUT -d 'bar' http://localhost:8080/db/foo
 curl -X DELETE http://localhost:8080/db/foo
 
 # look at the metrics
-curl -X GET -H "Accept: application/json" http://localhost:8080/observe/metrics/application | jq
+curl -X GET -H "Accept: application/json" http://localhost:8080/observe/metrics | jq
 ```

--- a/examples/declarative/metrics/README.md
+++ b/examples/declarative/metrics/README.md
@@ -167,27 +167,25 @@ curl -H "Accept: application/json" http://localhost:8080/observe/metrics | json_
 Expected output:
 ```
 {
-   "application" : {
-      "MetricsEndpoint.counted;application=MetricsExample;endpoint=MetricsEndpoint;location=method" : 1,
-      "MetricsEndpoint.gaugeValue;application=MetricsExample;endpoint=MetricsEndpoint" : 42,
-      "my-timed-metric" : {
-         "count;application=MetricsExample;endpoint=MetricsEndpoint" : 1,
-         "elapsedTime;application=MetricsExample;endpoint=MetricsEndpoint" : 8.81e-06,
-         "max;application=MetricsExample;endpoint=MetricsEndpoint" : 8.81e-06,
-         "mean;application=MetricsExample;endpoint=MetricsEndpoint" : 8.81e-06,
-         "p0.5;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
-         "p0.75;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
-         "p0.95;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
-         "p0.98;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
-         "p0.999;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
-         "p0.99;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06
-      }
+   "MetricsEndpoint.counted;application=MetricsExample;endpoint=MetricsEndpoint;location=method" : 1,
+   "MetricsEndpoint.gaugeValue;application=MetricsExample;endpoint=MetricsEndpoint" : 42,
+   "my-timed-metric" : {
+      "count;application=MetricsExample;endpoint=MetricsEndpoint" : 1,
+      "elapsedTime;application=MetricsExample;endpoint=MetricsEndpoint" : 8.81e-06,
+      "max;application=MetricsExample;endpoint=MetricsEndpoint" : 8.81e-06,
+      "mean;application=MetricsExample;endpoint=MetricsEndpoint" : 8.81e-06,
+      "p0.5;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
+      "p0.75;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
+      "p0.95;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
+      "p0.98;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
+      "p0.999;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06,
+      "p0.99;application=MetricsExample;endpoint=MetricsEndpoint" : 8.704e-06
    },
-   "vendor" : {
-      "requests.count" : 5
-   }
+   "requests.count" : 5
 }
 ```
+
+Earlier Helidon 27 builds group the same entries under `application` and `vendor` objects.
 
 All three metrics are visible (if we called all three endpoint mentioned above). Note that the non-gauge metrics will not be created unless the endpoint is called at least once.
 
@@ -201,24 +199,24 @@ Expected output:
 ```
 # HELP MetricsEndpoint_gaugeValue_bytes Metrics.Gauge annotation on method MetricsEndpoint.gaugeValue()
 # TYPE MetricsEndpoint_gaugeValue_bytes gauge
-MetricsEndpoint_gaugeValue_bytes{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",} 42.0
+MetricsEndpoint_gaugeValue_bytes{application="MetricsExample",endpoint="MetricsEndpoint",} 42.0
 # HELP my_timed_metric_seconds_max Metrics.Timed annotation on method MetricsEndpoint.timed()
 # TYPE my_timed_metric_seconds_max gauge
-my_timed_metric_seconds_max{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",} 8.81E-6
+my_timed_metric_seconds_max{application="MetricsExample",endpoint="MetricsEndpoint",} 8.81E-6
 # HELP my_timed_metric_seconds Metrics.Timed annotation on method MetricsEndpoint.timed()
 # TYPE my_timed_metric_seconds summary
-my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",quantile="0.5",} 0.0
-my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",quantile="0.75",} 0.0
-my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",quantile="0.95",} 0.0
-my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",quantile="0.98",} 0.0
-my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",quantile="0.99",} 0.0
-my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",quantile="0.999",} 0.0
-my_timed_metric_seconds_count{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",} 1.0
-my_timed_metric_seconds_sum{application="MetricsExample",endpoint="MetricsEndpoint",scope="application",} 8.81E-6
+my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",quantile="0.5",} 0.0
+my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",quantile="0.75",} 0.0
+my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",quantile="0.95",} 0.0
+my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",quantile="0.98",} 0.0
+my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",quantile="0.99",} 0.0
+my_timed_metric_seconds{application="MetricsExample",endpoint="MetricsEndpoint",quantile="0.999",} 0.0
+my_timed_metric_seconds_count{application="MetricsExample",endpoint="MetricsEndpoint",} 1.0
+my_timed_metric_seconds_sum{application="MetricsExample",endpoint="MetricsEndpoint",} 8.81E-6
 # HELP requests_count_total Each request (regardless of HTTP method) will increase this counter
 # TYPE requests_count_total counter
-requests_count_total{scope="vendor",} 6.0
+requests_count_total 6.0
 # HELP MetricsEndpoint_counted_none_total Metrics.Counted annotation on method MetricsEndpoint.counted()
 # TYPE MetricsEndpoint_counted_none_total counter
-MetricsEndpoint_counted_none_total{application="MetricsExample",endpoint="MetricsEndpoint",location="method",scope="application",} 1.0
+MetricsEndpoint_counted_none_total{application="MetricsExample",endpoint="MetricsEndpoint",location="method",} 1.0
 ```

--- a/examples/declarative/metrics/src/test/java/io/helidon/examples/declarative/metrics/DeclarativeMetricsTest.java
+++ b/examples/declarative/metrics/src/test/java/io/helidon/examples/declarative/metrics/DeclarativeMetricsTest.java
@@ -56,12 +56,11 @@ public class DeclarativeMetricsTest {
                 .request(JsonObject.class);
 
         assertThat(metricsResponse.status(), is(Status.OK_200));
-        var json = metricsResponse.entity();
+        var json = applicationMetrics(metricsResponse.entity());
 
         String metricName = "MetricsEndpoint.counted;application=MetricsExample;endpoint=MetricsEndpoint;location=method";
-        Optional<Integer> applicationOpt = json.objectValue("application")
-                .flatMap(it -> it.intValue(metricName));
-        assertThat(applicationOpt, OptionalMatcher.optionalValue(is(1)));
+        Optional<Integer> metricValue = json.intValue(metricName);
+        assertThat(metricValue, OptionalMatcher.optionalValue(is(1)));
     }
 
     @Test
@@ -79,13 +78,12 @@ public class DeclarativeMetricsTest {
                 .request(JsonObject.class);
 
         assertThat(metricsResponse.status(), is(Status.OK_200));
-        var json = metricsResponse.entity();
+        var json = applicationMetrics(metricsResponse.entity());
 
         String metricName = "my-timed-metric";
-        Optional<Integer> applicationOpt = json.objectValue("application")
-                .flatMap(it -> it.objectValue(metricName))
+        Optional<Integer> metricValue = json.objectValue(metricName)
                 .flatMap(it -> it.intValue("count;application=MetricsExample;endpoint=MetricsEndpoint"));
-        assertThat(applicationOpt, OptionalMatcher.optionalValue(is(1)));
+        assertThat(metricValue, OptionalMatcher.optionalValue(is(1)));
     }
 
     @Test
@@ -106,11 +104,14 @@ public class DeclarativeMetricsTest {
                 .request(JsonObject.class);
 
         assertThat(metricsResponse.status(), is(Status.OK_200));
-        var json = metricsResponse.entity();
+        var json = applicationMetrics(metricsResponse.entity());
 
         String metricName = "MetricsEndpoint.gaugeValue;application=MetricsExample;endpoint=MetricsEndpoint";
-        Optional<Integer> applicationOpt = json.objectValue("application")
-                .flatMap(it -> it.intValue(metricName));
-        assertThat(applicationOpt, OptionalMatcher.optionalValue(is(42)));
+        Optional<Integer> metricValue = json.intValue(metricName);
+        assertThat(metricValue, OptionalMatcher.optionalValue(is(42)));
+    }
+
+    private static JsonObject applicationMetrics(JsonObject metrics) {
+        return metrics.objectValue("application").orElse(metrics);
     }
 }

--- a/examples/metrics/exemplar/README.md
+++ b/examples/metrics/exemplar/README.md
@@ -38,20 +38,20 @@ curl -X GET http://localhost:8080/greet
 #output:  {"message":"Hola World!"}
 ```
 
-## Retrieve application metrics
+## Retrieve metrics
 
 ```
 # Prometheus format with exemplars
 
-curl -s -X GET http://localhost:8080/observe/metrics/application
-# TYPE application_counterForPersonalizedGreetings_total counter
-# HELP application_counterForPersonalizedGreetings_total 
-application_counterForPersonalizedGreetings_total 2 # {trace_id="78e61eed351f4c9d"} 1 1617812495.016000
+curl -s -X GET http://localhost:8080/observe/metrics
+# TYPE counterForPersonalizedGreetings_total counter
+# HELP counterForPersonalizedGreetings_total
+counterForPersonalizedGreetings_total 2 # {trace_id="78e61eed351f4c9d"} 1 1617812495.016000
 . . .
-# TYPE application_timerForGets_mean_seconds gauge
-application_timerForGets_mean_seconds 0.005772598385062112 # {trace_id="b22f13c37ba8b879"} 0.001563945 1617812578.687000
-# TYPE application_timerForGets_max_seconds gauge
-application_timerForGets_max_seconds 0.028018165 # {trace_id="a1b127002725143c"} 0.028018165 1617812467.524000
+# TYPE timerForGets_mean_seconds gauge
+timerForGets_mean_seconds 0.005772598385062112 # {trace_id="b22f13c37ba8b879"} 0.001563945 1617812578.687000
+# TYPE timerForGets_max_seconds gauge
+timerForGets_max_seconds 0.028018165 # {trace_id="a1b127002725143c"} 0.028018165 1617812467.524000
 ```
 The exemplars contain `trace_id` values tying them to specific samples.
 Note that the exemplar for the counter refers to the most recent update to the counter. 

--- a/examples/metrics/filtering/se/README.md
+++ b/examples/metrics/filtering/se/README.md
@@ -1,7 +1,7 @@
-# Helidon Filtering Metrics SE Example
+# Helidon Metrics Name Filtering SE Example
 
-This project implements a simple Hello World REST service using Helidon SE and demonstrates the
-optional metrics exemplar support.
+This project implements a simple Hello World REST service using Helidon SE and demonstrates narrowing the metrics endpoint
+report using its `name` query parameter.
 
 ## Build and run
 
@@ -24,24 +24,16 @@ curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http:
 curl -X GET http://localhost:8080/greet/Jose
 #Output: {"message":"Hola Jose!"}
 
-curl -X GET http://localhost:8080/greet          
+curl -X GET http://localhost:8080/greet
 #Output: {"message":"Hola World!"}
 ```
 
-## Retrieve application metrics
+## Retrieve selected metrics
+
+Use the registered meter name to select which meter family the metrics endpoint reports:
 
 ```shell
-# Prometheus format with exemplars
+curl -s 'http://localhost:8080/observe/metrics?name=counterForPersonalizedGreetings'
+```
 
-curl -s -X GET http://localhost:8080/observe/metrics/application
-```
-```
-# TYPE application_counterForPersonalizedGreetings_total counter
-# HELP application_counterForPersonalizedGreetings_total 
-application_counterForPersonalizedGreetings_total 2 # {trace_id="78e61eed351f4c9d"} 1 1617812495.016000
-. . .
-# TYPE application_timerForGets_mean_seconds gauge
-application_timerForGets_mean_seconds 0.005772598385062112 # {trace_id="b22f13c37ba8b879"} 0.001563945 1617812578.687000
-# TYPE application_timerForGets_max_seconds gauge
-application_timerForGets_max_seconds 0.028018165 # {trace_id="a1b127002725143c"} 0.028018165 1617812467.524000
-```
+The response contains the `counterForPersonalizedGreetings` meter family and does not contain `timerForGets`.

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -16,16 +16,9 @@
 
 package io.helidon.examples.metrics.filtering.se;
 
-import java.util.regex.Pattern;
-
 import io.helidon.config.Config;
 import io.helidon.logging.common.LogConfig;
-import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.MetricsConfig;
-import io.helidon.metrics.api.MetricsFactory;
-import io.helidon.metrics.api.ScopeConfig;
-import io.helidon.metrics.api.ScopingConfig;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
@@ -68,30 +61,8 @@ public final class Main {
 
         // By default, this will pick up application.yaml from the classpath
         Config config = Services.get(Config.class);
-
-        // Programmatically (not through config), tell the metrics feature to ignore the "gets" timer.
-        // To do so, create the scope config, then add it to the metrics config that ultimately
-        // the metrics feature class will use.
-        ScopeConfig scopeConfig = ScopeConfig.builder()
-                .name(Meter.Scope.APPLICATION)
-                .exclude(Pattern.compile(GreetService.TIMER_FOR_GETS))
-                .build();
-
-        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
-        // This global registry initialization can be removed once custom registries own their publishers.
-        Services.get(MeterRegistry.class);
-        MetricsConfig metricsConfig = MetricsConfig.builder(metricsFactory.metricsConfig())
-                .scoping(ScopingConfig.builder()
-                                 .putScope(Meter.Scope.APPLICATION, scopeConfig))
-                .warnOnMultipleRegistries(false)
-                .build();
-
-        MeterRegistry meterRegistry = metricsFactory.createMeterRegistry(metricsConfig);
-
-        MetricsObserver metrics = MetricsObserver.builder()
-                .meterRegistry(meterRegistry)
-                .metricsConfig(metricsConfig)
-                .build();
+        MeterRegistry meterRegistry = Services.get(MeterRegistry.class);
+        MetricsObserver metrics = MetricsObserver.create();
 
         server.featuresDiscoverServices(false)
                 .addFeature(ObserveFeature.just(metrics))

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/package-info.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Helidon SE example of controlling metrics using filtering.
+ * Helidon SE example of filtering the metrics endpoint report by meter name.
  */
 package io.helidon.examples.metrics.filtering.se;

--- a/examples/metrics/filtering/se/src/main/resources/application.yaml
+++ b/examples/metrics/filtering/se/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-tracing:
-  service: "hello-world"

--- a/examples/metrics/filtering/se/src/test/java/io/helidon/examples/metrics/filtering/se/MainTest.java
+++ b/examples/metrics/filtering/se/src/test/java/io/helidon/examples/metrics/filtering/se/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package io.helidon.examples.metrics.filtering.se;
 
 import java.util.Collections;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
@@ -31,6 +31,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
@@ -79,7 +80,7 @@ public class MainTest {
     }
 
     @Test
-    public void testMetrics() {
+    public void testMetricsNameFiltering() {
         try (Http1ClientResponse response = client.get("/greet").request()) {
             assertThat(response.as(String.class), containsString("Hello World!"));
         }
@@ -88,10 +89,23 @@ public class MainTest {
             assertThat(response.as(String.class), containsString("Hello Joe!"));
         }
 
-        try (Http1ClientResponse response = client.get("/observe/metrics/application").request()) {
+        try (Http1ClientResponse response = client.get("/observe/metrics").request()) {
             String openMetricsOutput = response.as(String.class);
-            assertThat("Metrics output", openMetricsOutput, not(containsString(GreetService.TIMER_FOR_GETS)));
-            assertThat("Metrics output", openMetricsOutput, containsString(GreetService.COUNTER_FOR_PERSONALIZED_GREETINGS));
+            assertThat("Unfiltered metrics output",
+                       openMetricsOutput,
+                       allOf(containsString(GreetService.TIMER_FOR_GETS),
+                             containsString(GreetService.COUNTER_FOR_PERSONALIZED_GREETINGS)));
+        }
+
+        try (Http1ClientResponse response = client.get("/observe/metrics")
+                .queryParam("name", GreetService.COUNTER_FOR_PERSONALIZED_GREETINGS)
+                .request()) {
+            String openMetricsOutput = response.as(String.class);
+            assertThat("Name-filtered metrics response status", response.status().code(), CoreMatchers.is(200));
+            assertThat("Name-filtered metrics output",
+                       openMetricsOutput,
+                       allOf(containsString(GreetService.COUNTER_FOR_PERSONALIZED_GREETINGS),
+                             not(containsString(GreetService.TIMER_FOR_GETS))));
         }
     }
 }

--- a/examples/metrics/http-status-count-se/README.md
+++ b/examples/metrics/http-status-count-se/README.md
@@ -60,18 +60,18 @@ curl -X GET http://localhost:8080/greet/Jose
 ## Try metrics
 ```shell
 # Prometheus Format
-curl -s -X GET http://localhost:8080/observe/metrics/application
+curl -s -X GET http://localhost:8080/observe/metrics
 ```
 
 ```listing
 ...
-# TYPE application_httpStatus_total counter
-# HELP application_httpStatus_total Counts the number of HTTP responses in each status category (1xx, 2xx, etc.)
-application_httpStatus_total{range="1xx"} 0
-application_httpStatus_total{range="2xx"} 5
-application_httpStatus_total{range="3xx"} 0
-application_httpStatus_total{range="4xx"} 0
-application_httpStatus_total{range="5xx"} 0
+# TYPE httpStatus_total counter
+# HELP httpStatus_total Counts the number of HTTP responses in each status category (1xx, 2xx, etc.)
+httpStatus_total{range="1xx"} 0
+httpStatus_total{range="2xx"} 5
+httpStatus_total{range="3xx"} 0
+httpStatus_total{range="4xx"} 0
+httpStatus_total{range="5xx"} 0
 ...
 ```
 # JSON Format

--- a/examples/metrics/http-status-count-se/README.md
+++ b/examples/metrics/http-status-count-se/README.md
@@ -1,6 +1,7 @@
 # http-status-count-se
 
-This Helidon SE project illustrates a service which updates a family of counters based on the HTTP status returned in each response.
+This Helidon SE project illustrates a service which updates a family of counters based on the final HTTP status returned
+in each response.
 
 The main source in this example is identical to that in the Helidon SE QuickStart application except in these ways:
 * The `HttpStatusMetricService` class creates and updates the status metrics.
@@ -66,8 +67,7 @@ curl -s -X GET http://localhost:8080/observe/metrics
 ```listing
 ...
 # TYPE httpStatus_total counter
-# HELP httpStatus_total Counts the number of HTTP responses in each status category (1xx, 2xx, etc.)
-httpStatus_total{range="1xx"} 0
+# HELP httpStatus_total Counts the number of HTTP responses in each final status category (2xx, 3xx, 4xx, and 5xx)
 httpStatus_total{range="2xx"} 5
 httpStatus_total{range="3xx"} 0
 httpStatus_total{range="4xx"} 0
@@ -82,7 +82,6 @@ curl -H "Accept: application/json" -X GET http://localhost:8080/observe/metrics
 ```json
 {
 ...
-    "httpStatus;range=1xx": 0,
     "httpStatus;range=2xx": 5,
     "httpStatus;range=3xx": 0,
     "httpStatus;range=4xx": 0,

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/HttpStatusMetricService.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/HttpStatusMetricService.java
@@ -28,12 +28,12 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
 /**
- * Helidon SE service to update a family of counters based on the HTTP status of each response. Add an instance of this service
- * to the application's routing.
+ * Helidon SE service to update a family of counters based on the final HTTP status of each response. Add an instance of this
+ * service to the application's routing.
  * <p>
- *     The service uses one {@link io.helidon.metrics.api.Counter} for each HTTP status family (1xx, 2xx, etc.).
+ *     The service uses one {@link io.helidon.metrics.api.Counter} for each final HTTP status family (2xx, 3xx, 4xx, and 5xx).
  *     All counters share the same name--{@value STATUS_COUNTER_NAME}--and each has the tag {@value STATUS_TAG_NAME} with
- *     value {@code 1xx}, {@code 2xx}, etc.
+ *     value {@code 2xx}, {@code 3xx}, {@code 4xx}, or {@code 5xx}.
  * </p>
  */
 public class HttpStatusMetricService implements HttpService {
@@ -42,7 +42,8 @@ public class HttpStatusMetricService implements HttpService {
 
     static final String STATUS_TAG_NAME = "range";
 
-    private static final String COUNTER_DESCR = "Counts the number of HTTP responses in each status category (1xx, 2xx, etc.)";
+    private static final String COUNTER_DESCR =
+            "Counts the number of HTTP responses in each final status category (2xx, 3xx, 4xx, and 5xx)";
 
     private static final AtomicInteger IN_PROGRESS = new AtomicInteger();
 
@@ -57,7 +58,7 @@ public class HttpStatusMetricService implements HttpService {
         MeterRegistry registry = Services.get(MeterRegistry.class);
 
         // Declare the counters and keep references to them.
-        for (int i = 1; i < responseCounters.length; i++) {
+        for (int i = 2; i < responseCounters.length; i++) {
 
             responseCounters[i] = registry.getOrCreate(
                     metricsFactory.counterBuilder(STATUS_COUNTER_NAME)
@@ -84,7 +85,7 @@ public class HttpStatusMetricService implements HttpService {
 
     private void logMetric(ServerResponse response) {
         int range = response.status().code() / 100;
-        if (range > 0 && range < responseCounters.length) {
+        if (range > 1 && range < responseCounters.length) {
             responseCounters[range].increment();
         }
         IN_PROGRESS.decrementAndGet();

--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
@@ -64,7 +64,7 @@ public class StatusTest {
 
     @BeforeEach
     void findStatusMetrics() {
-        for (int i = 1; i < STATUS_COUNTERS.length; i++) {
+        for (int i = 2; i < STATUS_COUNTERS.length; i++) {
             STATUS_COUNTERS[i] = meterRegistry.getOrCreate(
                     metricsFactory.counterBuilder(STATUS_COUNTER_NAME)
                             .tags(Set.of(metricsFactory.tagCreate(STATUS_TAG_NAME, i + "xx"))));
@@ -84,7 +84,7 @@ public class StatusTest {
     @Test
     void checkStatusAfterGreet() throws InterruptedException {
         long[] before = new long[6];
-        for (int i = 1; i < 6; i++) {
+        for (int i = 2; i < 6; i++) {
             before[i] = STATUS_COUNTERS[i].count();
         }
         try (Http1ClientResponse response = client.get("/greet")
@@ -99,7 +99,7 @@ public class StatusTest {
 
     void checkAfterStatus(Status status) throws InterruptedException {
         long[] before = new long[6];
-        for (int i = 1; i < 6; i++) {
+        for (int i = 2; i < 6; i++) {
             before[i] = STATUS_COUNTERS[i].count();
         }
         try (Http1ClientResponse response = client.get("/status/" + status.code())
@@ -124,7 +124,7 @@ public class StatusTest {
         }
 
         int family = status.code() / 100;
-        for (int i = 1; i < 6; i++) {
+        for (int i = 2; i < 6; i++) {
             long expectedDiff = i == family ? 1 : 0;
             assertThat("Diff in counter " + family + "xx", STATUS_COUNTERS[i].count() - before[i], is(expectedDiff));
         }

--- a/examples/metrics/kpi/README.md
+++ b/examples/metrics/kpi/README.md
@@ -41,7 +41,7 @@ curl -X GET http://localhost:8080/greet
 #Output: {"message":"Hola World!"}
 ```
 
-## Retrieve vendor metrics with key performance indicators
+## Retrieve key performance indicator metrics
 
 For brevity, the example output below shows only some of the KPI metrics. 
 
@@ -75,35 +75,35 @@ long-running.
 
 ## Prometheus format
 ```shell
-curl -s -X GET http://localhost:8080/observe/metrics/vendor
+curl -s -X GET http://localhost:8080/observe/metrics
 ```
 ```
 ...
-# TYPE vendor_requests_inFlight_current concurrent gauge
-# HELP vendor_requests_inFlight_current Measures the number of currently in-flight requests
-vendor_requests_inFlight_current 1
-# TYPE vendor_requests_inFlight_min concurrent gauge
-vendor_requests_inFlight_min 0
-# TYPE vendor_requests_inFlight_max concurrent gauge
-vendor_requests_inFlight_max 1
-# TYPE vendor_requests_load_total counter
-# HELP vendor_requests_load_total Measures the total number of in-flight requests and rates at which they occur
-vendor_requests_load_total 6
-# TYPE vendor_requests_load_rate_per_second gauge
-vendor_requests_load_rate_per_second 0.04932913209653636
-# TYPE vendor_requests_load_one_min_rate_per_second gauge
-vendor_requests_load_one_min_rate_per_second 0.025499793037824785
-# TYPE vendor_requests_load_five_min_rate_per_second gauge
-vendor_requests_load_five_min_rate_per_second 0.012963147773962286
-# TYPE vendor_requests_load_fifteen_min_rate_per_second gauge
-vendor_requests_load_fifteen_min_rate_per_second 0.005104944851522425
+# TYPE requests_inFlight_current concurrent gauge
+# HELP requests_inFlight_current Measures the number of currently in-flight requests
+requests_inFlight_current 1
+# TYPE requests_inFlight_min concurrent gauge
+requests_inFlight_min 0
+# TYPE requests_inFlight_max concurrent gauge
+requests_inFlight_max 1
+# TYPE requests_load_total counter
+# HELP requests_load_total Measures the total number of in-flight requests and rates at which they occur
+requests_load_total 6
+# TYPE requests_load_rate_per_second gauge
+requests_load_rate_per_second 0.04932913209653636
+# TYPE requests_load_one_min_rate_per_second gauge
+requests_load_one_min_rate_per_second 0.025499793037824785
+# TYPE requests_load_five_min_rate_per_second gauge
+requests_load_five_min_rate_per_second 0.012963147773962286
+# TYPE requests_load_fifteen_min_rate_per_second gauge
+requests_load_fifteen_min_rate_per_second 0.005104944851522425
 ...
 ```
 ## JSON output
 
 
 ```shell
-curl -s -X GET -H "Accept: application/json" http://localhost:8080/observe/metrics/vendor
+curl -s -X GET -H "Accept: application/json" http://localhost:8080/observe/metrics
 ```
 ```
 {


### PR DESCRIPTION
Prepares the examples for helidon-io/helidon#12504.

Updates the declarative metrics assertions and documentation to support both the legacy scope-grouped output and the new flat output. Reworks the SE metrics filtering example to demonstrate supported name-based endpoint report filtering now that core metrics scope filtering is intentionally inert. Refreshes the remaining metrics README commands and output samples for the unscoped endpoint.
