### PR TITLE
Update Declarative examples for Preview APIs (27.x)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,7 @@ env:
   HELIDON_PIPELINES: 'true'
   MVN_ARGS: |
     -B -fae -e
+    -nsu
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
     -Dmaven.wagon.http.retryHandler.count=3
 
@@ -60,6 +61,7 @@ jobs:
           cache: maven
       - name: Helidon Priming build
         run: |
+          rm -rf ~/.m2/repository/io/helidon
           mkdir -p ~/.m2/repository/io/helidon/
           echo "empty file" > ~/.m2/repository/io/helidon/empty.txt
           etc/scripts/prime-build.sh
@@ -83,6 +85,13 @@ jobs:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
+      - name: Remove cached Helidon artifacts
+        run: rm -rf ~/.m2/repository/io/helidon
+      - name: Download Maven Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: io-helidon-maven-artifacts
+          path: ~/.m2/repository/io/helidon
       - name: Copyright
         run: etc/scripts/copyright.sh
   checkstyle:
@@ -90,11 +99,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:
-      - name: Download Maven Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: io-helidon-maven-artifacts
-          path: ~/.m2/repository/io/helidon
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
@@ -104,6 +108,13 @@ jobs:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
+      - name: Remove cached Helidon artifacts
+        run: rm -rf ~/.m2/repository/io/helidon
+      - name: Download Maven Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: io-helidon-maven-artifacts
+          path: ~/.m2/repository/io/helidon
       - name: Checkstyle
         run: etc/scripts/checkstyle.sh
   shellcheck:
@@ -120,11 +131,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:
-      - name: Download Maven Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: io-helidon-maven-artifacts
-          path: ~/.m2/repository/io/helidon
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
@@ -134,6 +140,13 @@ jobs:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
+      - name: Remove cached Helidon artifacts
+        run: rm -rf ~/.m2/repository/io/helidon
+      - name: Download Maven Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: io-helidon-maven-artifacts
+          path: ~/.m2/repository/io/helidon
       - name: Spotbugs
         run: |
           mvn ${MVN_ARGS} \
@@ -155,11 +168,6 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/share/powershell
-      - name: Download Maven Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: io-helidon-maven-artifacts
-          path: ~/.m2/repository/io/helidon
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
@@ -169,6 +177,13 @@ jobs:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
+      - name: Remove cached Helidon artifacts
+        run: rm -rf ~/.m2/repository/io/helidon
+      - name: Download Maven Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: io-helidon-maven-artifacts
+          path: ~/.m2/repository/io/helidon
       - name: Maven build
         run: |
           mvn ${MVN_ARGS} \
@@ -195,11 +210,6 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/share/powershell
-      - name: Download Maven Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: io-helidon-maven-artifacts
-          path: ~/.m2/repository/io/helidon
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
@@ -209,6 +219,13 @@ jobs:
           website: jdk.java.net
           release: ea
           version: stable
+      - name: Remove cached Helidon artifacts
+        run: rm -rf ~/.m2/repository/io/helidon
+      - name: Download Maven Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: io-helidon-maven-artifacts
+          path: ~/.m2/repository/io/helidon
       - name: Maven build
         run: |
           mvn ${MVN_ARGS} \

--- a/examples/declarative/cors/src/main/java/io/helidon/examples/declarative/cors/HelloWorldEndpoint.java
+++ b/examples/declarative/cors/src/main/java/io/helidon/examples/declarative/cors/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.cors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -39,7 +38,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/cors/src/main/java/io/helidon/examples/declarative/cors/HelloWorldEndpoint.java
+++ b/examples/declarative/cors/src/main/java/io/helidon/examples/declarative/cors/HelloWorldEndpoint.java
@@ -27,7 +27,7 @@ import io.helidon.service.registry.Service;
 import io.helidon.webserver.cors.Cors;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/cors/src/main/resources/application.yaml
+++ b/examples/declarative/cors/src/main/resources/application.yaml
@@ -29,6 +29,3 @@ cors:
     - path-pattern: "/observe/health/*"
       allow-methods: "GET"
       allow-origins: "http://www.example.com"
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/data/src/main/java/io/helidon/examples/declarative/data/PokemonEndpoint.java
+++ b/examples/declarative/data/src/main/java/io/helidon/examples/declarative/data/PokemonEndpoint.java
@@ -29,7 +29,7 @@ import io.helidon.service.registry.Service;
 import io.helidon.transaction.Tx;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @Http.Path("/pokemon")
 @Service.Singleton
 @RestServer.Endpoint

--- a/examples/declarative/data/src/main/resources/application.yaml
+++ b/examples/declarative/data/src/main/resources/application.yaml
@@ -18,9 +18,6 @@ server:
   port: 8080
   host: 0.0.0.0
 
-declarative:
-  ignore-incubating: true
-
 data:
   url: "jdbc:mysql://localhost:3306/pokemons"
   sources:

--- a/examples/declarative/fault-tolerance/src/main/java/io/helidon/examples/declarative/faulttolerance/FaultToleranceEndpoint.java
+++ b/examples/declarative/fault-tolerance/src/main/java/io/helidon/examples/declarative/faulttolerance/FaultToleranceEndpoint.java
@@ -25,7 +25,7 @@ import io.helidon.http.Http;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING)
+@SuppressWarnings(Api.SUPPRESS_PREVIEW)
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/ft") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/fault-tolerance/src/main/resources/application.yaml
+++ b/examples/declarative/fault-tolerance/src/main/resources/application.yaml
@@ -17,6 +17,3 @@
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/health/src/main/java/io/helidon/examples/declarative/health/HelloWorldEndpoint.java
+++ b/examples/declarative/health/src/main/java/io/helidon/examples/declarative/health/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.health;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -35,7 +34,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/health/src/main/java/io/helidon/examples/declarative/health/HelloWorldEndpoint.java
+++ b/examples/declarative/health/src/main/java/io/helidon/examples/declarative/health/HelloWorldEndpoint.java
@@ -26,7 +26,7 @@ import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/health/src/main/resources/application.yaml
+++ b/examples/declarative/health/src/main/resources/application.yaml
@@ -29,7 +29,3 @@ server:
       observers:
         health:
           details: true
-
-# Ignore this feature's warning
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/metrics/src/main/java/io/helidon/examples/declarative/metrics/MetricsEndpoint.java
+++ b/examples/declarative/metrics/src/main/java/io/helidon/examples/declarative/metrics/MetricsEndpoint.java
@@ -27,7 +27,7 @@ import io.helidon.metrics.api.Metrics;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/metrics/src/main/resources/application.yaml
+++ b/examples/declarative/metrics/src/main/resources/application.yaml
@@ -17,6 +17,3 @@
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/scheduling/src/main/resources/application.yaml
+++ b/examples/declarative/scheduling/src/main/resources/application.yaml
@@ -18,6 +18,3 @@ app:
   scheduling:
     refresh-task:
       expression: "0/2 * * * * ?"
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/security/src/main/java/io/helidon/examples/declarative/security/HelloWorldEndpoint.java
+++ b/examples/declarative/security/src/main/java/io/helidon/examples/declarative/security/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.security;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -37,7 +36,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/security/src/main/java/io/helidon/examples/declarative/security/HelloWorldEndpoint.java
+++ b/examples/declarative/security/src/main/java/io/helidon/examples/declarative/security/HelloWorldEndpoint.java
@@ -28,7 +28,7 @@ import io.helidon.security.annotations.Authorized;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/security/src/main/resources/application.yaml
+++ b/examples/declarative/security/src/main/resources/application.yaml
@@ -36,7 +36,3 @@ security:
           - login: "jack"
             password: "changeit"
             roles: ["user"]
-
-# Ignore this feature's warning
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
+++ b/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.tracing;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -38,7 +37,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Hello") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Hello}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
+++ b/examples/declarative/tracing/src/main/java/io/helidon/examples/declarative/tracing/HelloWorldEndpoint.java
@@ -28,7 +28,7 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.Tracing;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING)
+@SuppressWarnings(Api.SUPPRESS_PREVIEW)
 @RestServer.Endpoint
 @Http.Path("/hello")
 @Service.Singleton

--- a/examples/declarative/tracing/src/main/resources/application.yaml
+++ b/examples/declarative/tracing/src/main/resources/application.yaml
@@ -18,9 +18,6 @@ server:
   port: 8080
   host: 0.0.0.0
 
-declarative:
-  ignore-incubating: true
-
 app:
   greeting: "Hello"
 

--- a/examples/declarative/validation/src/main/java/io/helidon/examples/declarative/validation/ValidationEndpoint.java
+++ b/examples/declarative/validation/src/main/java/io/helidon/examples/declarative/validation/ValidationEndpoint.java
@@ -25,7 +25,7 @@ import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/validate") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/validation/src/main/resources/application.yaml
+++ b/examples/declarative/validation/src/main/resources/application.yaml
@@ -21,6 +21,3 @@ server:
     # THIS MUST NOT BE USED IN PRODUCTION!
     # exception message will be sent back over the network - this may give potential attackers information about your application
     include-entity: true
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webclient/src/main/java/io/helidon/examples/declarative/webclient/HelloWorldServerEndpoint.java
+++ b/examples/declarative/webclient/src/main/java/io/helidon/examples/declarative/webclient/HelloWorldServerEndpoint.java
@@ -18,7 +18,6 @@ package io.helidon.examples.declarative.webclient;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
 import io.helidon.http.Status;
@@ -34,7 +33,7 @@ class HelloWorldServerEndpoint implements HelloWorldApi {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldServerEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldServerEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webclient/src/main/resources/application.yaml
+++ b/examples/declarative/webclient/src/main/resources/application.yaml
@@ -22,6 +22,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webserver/hello-world-json/src/main/java/io/helidon/examples/declarative/webserver/helloworld/json/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world-json/src/main/java/io/helidon/examples/declarative/webserver/helloworld/json/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.webserver.helloworld.json;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -35,7 +34,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webserver/hello-world-json/src/main/java/io/helidon/examples/declarative/webserver/helloworld/json/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world-json/src/main/java/io/helidon/examples/declarative/webserver/helloworld/json/HelloWorldEndpoint.java
@@ -26,7 +26,7 @@ import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING)
+@SuppressWarnings(Api.SUPPRESS_PREVIEW)
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/webserver/hello-world-json/src/main/resources/application.yaml
+++ b/examples/declarative/webserver/hello-world-json/src/main/resources/application.yaml
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webserver/hello-world-jsonb/src/main/java/io/helidon/examples/declarative/webserver/helloworld/jsonb/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world-jsonb/src/main/java/io/helidon/examples/declarative/webserver/helloworld/jsonb/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.webserver.helloworld.jsonb;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -35,7 +34,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webserver/hello-world-jsonb/src/main/java/io/helidon/examples/declarative/webserver/helloworld/jsonb/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world-jsonb/src/main/java/io/helidon/examples/declarative/webserver/helloworld/jsonb/HelloWorldEndpoint.java
@@ -26,7 +26,7 @@ import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/webserver/hello-world-jsonb/src/main/resources/application.yaml
+++ b/examples/declarative/webserver/hello-world-jsonb/src/main/resources/application.yaml
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/webserver/hello-world/src/main/java/io/helidon/examples/declarative/webserver/helloworld/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world/src/main/java/io/helidon/examples/declarative/webserver/helloworld/HelloWorldEndpoint.java
@@ -19,7 +19,6 @@ package io.helidon.examples.declarative.webserver.helloworld;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.Api;
-import io.helidon.common.Default;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Configuration;
 import io.helidon.http.Http;
@@ -35,7 +34,7 @@ class HelloWorldEndpoint {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    HelloWorldEndpoint(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    HelloWorldEndpoint(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/declarative/webserver/hello-world/src/main/java/io/helidon/examples/declarative/webserver/helloworld/HelloWorldEndpoint.java
+++ b/examples/declarative/webserver/hello-world/src/main/java/io/helidon/examples/declarative/webserver/helloworld/HelloWorldEndpoint.java
@@ -26,7 +26,7 @@ import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 
-@SuppressWarnings(Api.SUPPRESS_INCUBATING) // Helidon declarative is an incubating feature
+@SuppressWarnings(Api.SUPPRESS_PREVIEW) // Helidon declarative is a preview feature
 @RestServer.Endpoint // webserver declarative endpoint
 @Http.Path("/hello") // path to serve this endpoint on
 @Service.Singleton // service registry scope (must be singleton)

--- a/examples/declarative/webserver/hello-world/src/main/resources/application.yaml
+++ b/examples/declarative/webserver/hello-world/src/main/resources/application.yaml
@@ -20,6 +20,3 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
-
-declarative:
-  ignore-incubating: true

--- a/examples/declarative/websocket/src/main/java/io/helidon/examples/declarative/websocket/MessageBoardWsEndpoint.java
+++ b/examples/declarative/websocket/src/main/java/io/helidon/examples/declarative/websocket/MessageBoardWsEndpoint.java
@@ -28,7 +28,7 @@ import io.helidon.websocket.WsSession;
 @WebSocketServer.Endpoint
 @Http.Path("/websocket")
 @Service.Singleton
-@SuppressWarnings(Api.SUPPRESS_INCUBATING)
+@SuppressWarnings(Api.SUPPRESS_PREVIEW)
 class MessageBoardWsEndpoint {
     private static final System.Logger LOGGER = System.getLogger(MessageBoardWsEndpoint.class.getName());
 

--- a/examples/declarative/websocket/src/main/java/io/helidon/examples/declarative/websocket/MessageQueueHttpEndpoint.java
+++ b/examples/declarative/websocket/src/main/java/io/helidon/examples/declarative/websocket/MessageQueueHttpEndpoint.java
@@ -26,7 +26,7 @@ import io.helidon.webserver.http.RestServer;
 @Http.Path("/rest")
 @Service.Singleton
 @RestServer.Endpoint
-@SuppressWarnings(Api.SUPPRESS_INCUBATING)
+@SuppressWarnings(Api.SUPPRESS_PREVIEW)
 class MessageQueueHttpEndpoint {
     private static final System.Logger LOGGER = System.getLogger(MessageQueueHttpEndpoint.class.getName());
 

--- a/examples/declarative/websocket/src/main/resources/application.yaml
+++ b/examples/declarative/websocket/src/main/resources/application.yaml
@@ -23,8 +23,3 @@ server:
       classpath:
         - context: "web"
           location: "WEB"
-
-
-# Ignore this feature's warning
-declarative:
-  ignore-incubating: true

--- a/examples/quickstarts/helidon-quickstart-inject/src/main/java/io/helidon/examples/quickstart/inject/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-inject/src/main/java/io/helidon/examples/quickstart/inject/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package io.helidon.examples.quickstart.inject;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.Default;
 import io.helidon.config.Configuration;
 import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
@@ -58,7 +57,7 @@ class GreetService implements HttpService {
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
     @Service.Inject
-    GreetService(@Default.Value("Ciao") @Configuration.Value("app.greeting") String greeting) {
+    GreetService(@Configuration.Value("${app.greeting:Ciao}") String greeting) {
         this.greeting.set(greeting);
     }
 

--- a/examples/quickstarts/helidon-quickstart-inject/src/main/resources/application.yaml
+++ b/examples/quickstarts/helidon-quickstart-inject/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,3 @@ server:
   #      metrics:
   #      health:
   #        enabled: false
-
-declarative:
-  ignore-incubating: true


### PR DESCRIPTION
Updates the 27.x Declarative examples for the Preview API status:

- Removes the obsolete `declarative.ignore-incubating` setting and related comments.
- Uses `@Configuration.Value("${key:default}")` expressions instead of pairing `@Configuration.Value` with `@Default.Value`.
- Replaces Incubating API suppressions with Preview suppressions.

Depends on helidon-io/helidon#12523.
